### PR TITLE
Fixed redis Connection namespace

### DIFF
--- a/src/drivers/redis/Queue.php
+++ b/src/drivers/redis/Queue.php
@@ -11,7 +11,7 @@ use yii\exceptions\InvalidArgumentException;
 use yii\exceptions\NotSupportedException;
 use yii\queue\cli\Queue as CliQueue;
 use yii\queue\serializers\SerializerInterface;
-use yii\redis\Connection;
+use yii\db\redis\Connection;
 
 /**
  * Redis Queue.


### PR DESCRIPTION
Fixed redis Connection namespace

config/common.php
```php
    'queue' => [
        '__class' => \yii\queue\redis\Queue::class,
    ],

    \yii\db\redis\Connection::class => \yii\di\Reference::to('redis'),
    'redis' => [
        '__class' => \yii\db\redis\Connection::class,
    ],
```