### PR TITLE
Getting unknown property: yii\queue\file\Queue::path

### DIFF
--- a/src/drivers/file/Queue.php
+++ b/src/drivers/file/Queue.php
@@ -87,7 +87,15 @@ class Queue extends CliQueue
             }
         });
     }
-
+    
+   /**
+     * {@inheritdoc}
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+    
     /**
      * @inheritdoc
      */


### PR DESCRIPTION
Failed to get the property because it is protected.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   |
| Fixed issues  |

PHP version 7.3.1