### PR TITLE
Trying to get property 'path' of non-object

### DIFF
--- a/src/cli/Action.php
+++ b/src/cli/Action.php
@@ -31,9 +31,9 @@ abstract class Action extends BaseAction
     /**
      * @inheritdoc
      */
-    public function init()
+    public function __construct($id, $controller)
     {
-        parent::init();
+        parent::__construct($id, $controller);
 
         if (!$this->queue && ($this->controller instanceof Command)) {
             $this->queue = $this->controller->queue;


### PR DESCRIPTION
since the init() method has been removed, initialization is moved to __construct

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   |
| Fixed issues  |

PHP version 7.3.1