### PR TITLE
Log exception on job fail

### DIFF
--- a/src/Exception/JobFailureException.php
+++ b/src/Exception/JobFailureException.php
@@ -17,7 +17,7 @@ class JobFailureException extends RuntimeException
         $this->queueMessage = $message;
 
         $error = $previous->getMessage();
-        $messageId = $message->getId();
+        $messageId = $message->getId() ?? 'null';
         $messageText = "Processing of message #$messageId is stopped because of an exception:\n$error.";
 
         parent::__construct($messageText, 0, $previous);

--- a/src/Exception/JobFailureException.php
+++ b/src/Exception/JobFailureException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Queue\Exception;
+
+use RuntimeException;
+use Throwable;
+use Yiisoft\Yii\Queue\MessageInterface;
+
+class JobFailureException extends RuntimeException
+{
+    private MessageInterface $queueMessage;
+
+    public function __construct(MessageInterface $message, Throwable $previous)
+    {
+        $this->queueMessage = $message;
+
+        $error = $previous->getMessage();
+        $messageId = $message->getId();
+        $messageText = "Processing of message #$messageId is stopped because of an exception:\n$error.";
+
+        parent::__construct($messageText, 0, $previous);
+    }
+
+    public function getQueueMessage(): MessageInterface
+    {
+        return $this->queueMessage;
+    }
+}

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -13,6 +13,7 @@ use Yiisoft\Injector\Injector;
 use Yiisoft\Yii\Queue\Event\AfterExecution;
 use Yiisoft\Yii\Queue\Event\BeforeExecution;
 use Yiisoft\Yii\Queue\Event\JobFailure;
+use Yiisoft\Yii\Queue\Exception\JobFailureException;
 use Yiisoft\Yii\Queue\MessageInterface;
 use Yiisoft\Yii\Queue\Queue;
 
@@ -71,13 +72,9 @@ final class Worker implements WorkerInterface
                 );
             }
         } catch (Throwable $exception) {
-            $this->logger->error(
-                "Processing of message #{message} is stopped because of an exception:\n{exception}.",
-                [
-                    'message' => $message->getId(),
-                    'exception' => $exception->getMessage(),
-                ]
-            );
+            $exception = new JobFailureException($message, $exception);
+            $this->logger->error($exception);
+
             $event = new JobFailure($queue, $message, $exception);
             $this->dispatcher->dispatch($event);
 


### PR DESCRIPTION
Only message text is logged now, making it harder to debug.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | ❌
