### PR TITLE
Bugfix: use channel-defined middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ You can use any of these formats to define a middleware:
     or `MiddlewareConsumeInterface` depending on the place you use it.
 - An array in the format of [yiisoft/definitions](https://github.com/yiisoft/definitions).
     **Only if you use yiisoft/definitions and yiisoft/di**.
-- A `callable`: `fn() => // do stuff`, `$object->foo(...)`, etc. It will be executed through the [yiisoft/injector](yiisoft/injector), so all the dependencies of your callable will be resolved
+- A `callable`: `fn() => // do stuff`, `$object->foo(...)`, etc. It will be executed through the [yiisoft/injector](https://github.com/yiisoft/injector), so all the dependencies of your callable will be resolved
 - A string for your DI container to resolve the middleware, e.g. `FooMiddleware::class`
 
 Middleware will be executed forwards in the same order they are defined. If you define it like the following:
@@ -252,10 +252,11 @@ With push middlewares you can define an adapter object at the runtime, not in th
 There is a restriction: by the time all middlewares are executed in the forward order, the adapter must be specified
 in the `PushRequest` object. You will get a `AdapterNotConfiguredException`, if it isn't.
 
-You have two places to define push middlewares:
+You have three places to define push middlewares:
 1. `PushMiddlewareDispatcher`. You can pass it either to the constructor, or to the `withMiddlewares()` method, which  
     creates a completely new dispatcher object with only those middlewares, which are passed as arguments.
-2. Put middlewares into the `Queue::push()` method like this: `$queue->push($message, ...$middlewares)`. These middlewares will always be executed after those which are in the `PushMiddlewareDispatcher`.
+2. Pass middlewares to the `Queue::withMiddlewares()` or `Queue::withMiddlewaresAdded()` method. The difference is that the first method will completely replace an existing middleware stack, while the second one will add passed middlewares to the end of the existing stack. These middlewares will be executed after the common ones, passed directly to the `PushMiddlewareDispatcher`. It's useful when defining a queue channel. Both methods return a new instance of the `Queue` class.
+3. Put middlewares into the `Queue::push()` method like this: `$queue->push($message, ...$middlewares)`. These middlewares will be executed after those which are in the `PushMiddlewareDispatcher` and which are passed to the `Queue::withMiddlewares()` and `Queue::withMiddlewaresAdded()`, and only for the message with which they are passed.
 
 ### Consume pipeline
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,8 @@ You can use any of these formats to define a middleware:
     or `MiddlewareConsumeInterface` depending on the place you use it.
 - An array in the format of [yiisoft/definitions](https://github.com/yiisoft/definitions).
     **Only if you use yiisoft/definitions and yiisoft/di**.
-- A `callable`: `fn() => // do stuff`, `$object->foo(...)`, etc. It will be executed through the [yiisoft/injector](https://github.com/yiisoft/injector), so all the dependencies of your callable will be resolved
+- A `callable`: `fn() => // do stuff`, `$object->foo(...)`, etc. It will be executed through the
+[yiisoft/injector](https://github.com/yiisoft/injector), so all the dependencies of your callable will be resolved.
 - A string for your DI container to resolve the middleware, e.g. `FooMiddleware::class`
 
 Middleware will be executed forwards in the same order they are defined. If you define it like the following:
@@ -253,10 +254,18 @@ There is a restriction: by the time all middlewares are executed in the forward 
 in the `PushRequest` object. You will get a `AdapterNotConfiguredException`, if it isn't.
 
 You have three places to define push middlewares:
+
 1. `PushMiddlewareDispatcher`. You can pass it either to the constructor, or to the `withMiddlewares()` method, which  
-    creates a completely new dispatcher object with only those middlewares, which are passed as arguments.
-2. Pass middlewares to the `Queue::withMiddlewares()` or `Queue::withMiddlewaresAdded()` method. The difference is that the first method will completely replace an existing middleware stack, while the second one will add passed middlewares to the end of the existing stack. These middlewares will be executed after the common ones, passed directly to the `PushMiddlewareDispatcher`. It's useful when defining a queue channel. Both methods return a new instance of the `Queue` class.
-3. Put middlewares into the `Queue::push()` method like this: `$queue->push($message, ...$middlewares)`. These middlewares will be executed after those which are in the `PushMiddlewareDispatcher` and which are passed to the `Queue::withMiddlewares()` and `Queue::withMiddlewaresAdded()`, and only for the message with which they are passed.
+creates a completely new dispatcher object with only those middlewares, which are passed as arguments.
+2. Pass middlewares to either `Queue::withMiddlewares()` or `Queue::withMiddlewaresAdded()` methods. The difference is 
+that the former will completely replace an existing middleware stack, while the latter will add passed middlewares to 
+the end of the existing stack. These middlewares will be executed after the common ones, passed directly to the 
+`PushMiddlewareDispatcher`. It's useful when defining a queue channel. Both methods return a new instance of the `Queue` 
+class.
+3. Put middlewares into the `Queue::push()` method like this: `$queue->push($message, ...$middlewares)`. These
+middlewares have the lowest priority and will be executed after those which are in the `PushMiddlewareDispatcher` and 
+the ones passed to the `Queue::withMiddlewares()` and `Queue::withMiddlewaresAdded()` and only for the message passed 
+along with them.
 
 ### Consume pipeline
 

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -151,7 +151,7 @@ final class Queue implements QueueInterface
         return new class (
             $this->adapterPushHandler,
             $this->pushMiddlewareDispatcher,
-            $middlewares
+            [...array_values($this->middlewareDefinitions), ...array_values($middlewares)]
         ) implements MessageHandlerPushInterface {
             public function __construct(
                 private AdapterPushHandler $adapterPushHandler,

--- a/tests/Integration/MiddlewareTest.php
+++ b/tests/Integration/MiddlewareTest.php
@@ -32,6 +32,9 @@ final class MiddlewareTest extends TestCase
             'initial',
             'common 1',
             'common 2',
+            'channel 1',
+            'channel 2',
+            'channel 3',
             'message 1',
             'message 2',
         ];
@@ -56,6 +59,9 @@ final class MiddlewareTest extends TestCase
                 $this->createMock(QueueInterface::class),
             ),
         );
+        $queue = $queue
+            ->withMiddlewares(new TestMiddleware('channel 1'), new TestMiddleware('channel 2'))
+            ->withMiddlewaresAdded(new TestMiddleware('channel 3'));
 
         $message = new Message('test', ['initial']);
         $messagePushed = $queue->push(

--- a/tests/Integration/MiddlewareTest.php
+++ b/tests/Integration/MiddlewareTest.php
@@ -60,6 +60,7 @@ final class MiddlewareTest extends TestCase
             ),
         );
         $queue = $queue
+            ->withMiddlewares(new TestMiddleware('Won\'t be executed'))
             ->withMiddlewares(new TestMiddleware('channel 1'), new TestMiddleware('channel 2'))
             ->withMiddlewaresAdded(new TestMiddleware('channel 3'));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | ❌

There were used only common and message-related middlewares. Now channel-defined ones are already in use.