### PR TITLE
Raise `yiisoft/yii-console` required version to `^2.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.0",
         "psr/log": "^2.0|^3.0",
-        "yiisoft/yii-console": "^1.0",
+        "yiisoft/yii-console": "^2.0",
         "yiisoft/definitions": "^1.0|^2.0|^3.0",
         "yiisoft/friendly-exception": "^1.0",
         "yiisoft/injector": "^1.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
