### PR TITLE
Make `pcntl` PHP extension optional

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -1,6 +1,13 @@
 {
-    "symbol-whitelist" : [
+    "symbol-whitelist": [
         "Yiisoft\\Yii\\Debug\\Collector\\CollectorTrait",
-        "Yiisoft\\Yii\\Debug\\Collector\\SummaryCollectorInterface"
+        "Yiisoft\\Yii\\Debug\\Collector\\SummaryCollectorInterface",
+        "pcntl_signal",
+        "pcntl_signal_dispatch",
+        "SIGCONT",
+        "SIGHUP",
+        "SIGINT",
+        "SIGTERM",
+        "SIGTSTP"
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.0",
-        "ext-pcntl": "*",
         "psr/log": "^2.0|^3.0",
         "psr/container": "^1.0|^2.0",
         "yiisoft/yii-console": "^2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -