### PR TITLE
Remove `$middlewareDefinitions` from `QueueInterface::push()`

### DIFF
--- a/docs/guide/en/debug-integration-advanced.md
+++ b/docs/guide/en/debug-integration-advanced.md
@@ -6,7 +6,7 @@ Use this guide when you need to understand which events are tracked by the queue
 
 The integration is based on `Yiisoft\Queue\Debug\QueueCollector` and captures:
 
-- Pushed messages grouped by queue name (including middleware definitions passed to `push()`).
+- Pushed messages grouped by queue name.
 - Message status checks performed via `QueueInterface::status()`.
 - Messages processed by a worker grouped by queue name.
 

--- a/docs/guide/en/usage.md
+++ b/docs/guide/en/usage.md
@@ -25,7 +25,7 @@ For example, the official AMQP adapter supports delays: <https://github.com/yiis
 
 ```php
 $delayMiddleware = $container->get(\Yiisoft\Queue\Middleware\Push\Implementation\DelayMiddlewareInterface::class);
-$queue->push($message, $delayMiddleware->withDelay(5 * 60));
+$queue->withMiddlewaresAdded($delayMiddleware->withDelay(5 * 60))->push($message);
 ```
 
 **Important:** Not every adapter (such as synchronous adapter) supports delayed execution.

--- a/src/Debug/QueueCollector.php
+++ b/src/Debug/QueueCollector.php
@@ -8,7 +8,6 @@ use Yiisoft\Queue\MessageStatus;
 use Yiisoft\Yii\Debug\Collector\CollectorTrait;
 use Yiisoft\Yii\Debug\Collector\SummaryCollectorInterface;
 use Yiisoft\Queue\Message\MessageInterface;
-use Yiisoft\Queue\Middleware\Push\MiddlewarePushInterface;
 use Yiisoft\Queue\QueueInterface;
 
 use function count;
@@ -46,18 +45,14 @@ final class QueueCollector implements SummaryCollectorInterface
         ];
     }
 
-    public function collectPush(
-        string $queueName,
-        MessageInterface $message,
-        string|array|callable|MiddlewarePushInterface ...$middlewareDefinitions,
-    ): void {
+    public function collectPush(string $queueName, MessageInterface $message): void
+    {
         if (!$this->isActive()) {
             return;
         }
 
         $this->pushes[$queueName][] = [
             'message' => $message,
-            'middlewares' => $middlewareDefinitions,
         ];
     }
 

--- a/src/Debug/QueueDecorator.php
+++ b/src/Debug/QueueDecorator.php
@@ -6,7 +6,6 @@ namespace Yiisoft\Queue\Debug;
 
 use Yiisoft\Queue\MessageStatus;
 use Yiisoft\Queue\Message\MessageInterface;
-use Yiisoft\Queue\Middleware\Push\MiddlewarePushInterface;
 use Yiisoft\Queue\QueueInterface;
 
 final class QueueDecorator implements QueueInterface
@@ -24,12 +23,10 @@ final class QueueDecorator implements QueueInterface
         return $result;
     }
 
-    public function push(
-        MessageInterface $message,
-        string|array|callable|MiddlewarePushInterface ...$middlewareDefinitions,
-    ): MessageInterface {
-        $message = $this->queue->push($message, ...$middlewareDefinitions);
-        $this->collector->collectPush($this->queue->getName(), $message, ...$middlewareDefinitions);
+    public function push(MessageInterface $message): MessageInterface
+    {
+        $message = $this->queue->push($message);
+        $this->collector->collectPush($this->queue->getName(), $message);
         return $message;
     }
 

--- a/src/Middleware/FailureHandling/Implementation/ExponentialDelayMiddleware.php
+++ b/src/Middleware/FailureHandling/Implementation/ExponentialDelayMiddleware.php
@@ -10,7 +10,7 @@ use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 use Yiisoft\Queue\Middleware\FailureHandling\MessageFailureHandlerInterface;
 use Yiisoft\Queue\Middleware\FailureHandling\MiddlewareFailureInterface;
 use Yiisoft\Queue\Middleware\Push\Implementation\DelayMiddlewareInterface;
-use Yiisoft\Queue\Middleware\Push\Implementation\NoopMessageHandlerPush;
+use Yiisoft\Queue\Middleware\Push\NoopMessageHandlerPush;
 use Yiisoft\Queue\QueueInterface;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureEnvelope;
 

--- a/src/Middleware/FailureHandling/Implementation/ExponentialDelayMiddleware.php
+++ b/src/Middleware/FailureHandling/Implementation/ExponentialDelayMiddleware.php
@@ -10,6 +10,7 @@ use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 use Yiisoft\Queue\Middleware\FailureHandling\MessageFailureHandlerInterface;
 use Yiisoft\Queue\Middleware\FailureHandling\MiddlewareFailureInterface;
 use Yiisoft\Queue\Middleware\Push\Implementation\DelayMiddlewareInterface;
+use Yiisoft\Queue\Middleware\Push\Implementation\NoopMessageHandlerPush;
 use Yiisoft\Queue\QueueInterface;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureEnvelope;
 
@@ -64,12 +65,11 @@ final class ExponentialDelayMiddleware implements MiddlewareFailureInterface
         $message = $request->getMessage();
         if ($this->suites($message)) {
             $envelope = new FailureEnvelope($message, $this->createNewMeta($message));
+            $envelope = $this->delayMiddleware
+                ->withDelay($this->getDelay($envelope))
+                ->processPush($envelope, new NoopMessageHandlerPush());
             $queue = $this->queue ?? $request->getQueue();
-            $middlewareDefinitions = $this->delayMiddleware->withDelay($this->getDelay($envelope));
-            $messageNew = $queue->push(
-                $envelope,
-                $middlewareDefinitions,
-            );
+            $messageNew = $queue->push($envelope);
 
             return $request->withMessage($messageNew);
         }

--- a/src/Middleware/Push/Implementation/NoopMessageHandlerPush.php
+++ b/src/Middleware/Push/Implementation/NoopMessageHandlerPush.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Queue\Middleware\Push\Implementation;
+
+use Yiisoft\Queue\Message\MessageInterface;
+use Yiisoft\Queue\Middleware\Push\MessageHandlerPushInterface;
+
+/**
+ * @internal
+ */
+final class NoopMessageHandlerPush implements MessageHandlerPushInterface
+{
+    public function handlePush(MessageInterface $message): MessageInterface
+    {
+        return $message;
+    }
+}

--- a/src/Middleware/Push/NoopMessageHandlerPush.php
+++ b/src/Middleware/Push/NoopMessageHandlerPush.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Queue\Middleware\Push\Implementation;
+namespace Yiisoft\Queue\Middleware\Push;
 
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\Push\MessageHandlerPushInterface;

--- a/src/Middleware/Push/NoopMessageHandlerPush.php
+++ b/src/Middleware/Push/NoopMessageHandlerPush.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Yiisoft\Queue\Middleware\Push;
 
 use Yiisoft\Queue\Message\MessageInterface;
-use Yiisoft\Queue\Middleware\Push\MessageHandlerPushInterface;
 
 /**
  * @internal

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -55,10 +55,8 @@ final class Queue implements QueueInterface
         return $this->name;
     }
 
-    public function push(
-        MessageInterface $message,
-        MiddlewarePushInterface|callable|array|string ...$middlewareDefinitions,
-    ): MessageInterface {
+    public function push(MessageInterface $message): MessageInterface
+    {
         $this->logger->debug(
             'Preparing to push message with message type "{messageType}".',
             ['messageType' => $message->getType()],
@@ -66,7 +64,7 @@ final class Queue implements QueueInterface
 
         $message = $this->pushMiddlewareDispatcher->dispatch(
             $message,
-            $this->createPushHandler(...$middlewareDefinitions),
+            $this->createPushHandler(),
         );
 
         if ($this->isSynchronous()) {
@@ -162,12 +160,12 @@ final class Queue implements QueueInterface
         return $this->loop->canContinue();
     }
 
-    private function createPushHandler(MiddlewarePushInterface|callable|array|string ...$middlewares): MessageHandlerPushInterface
+    private function createPushHandler(): MessageHandlerPushInterface
     {
         return new class (
             $this->finalPushHandler,
             $this->pushMiddlewareDispatcher,
-            array_merge($this->middlewareDefinitions, $middlewares),
+            $this->middlewareDefinitions,
         ) implements MessageHandlerPushInterface {
             public function __construct(
                 /**

--- a/src/QueueInterface.php
+++ b/src/QueueInterface.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Yiisoft\Queue;
 
 use Yiisoft\Queue\Message\MessageInterface;
-use Yiisoft\Queue\Middleware\Push\MiddlewarePushInterface;
 
 interface QueueInterface
 {
     /**
      * Pushes a message into the queue.
      *
-     * @param array|callable|MiddlewarePushInterface|string ...$middlewareDefinitions
-     * @return MessageInterface
+     * @param MessageInterface $message The message to push.
+     *
+     * @return MessageInterface The pushed message, possibly enriched with metadata such as an assigned ID.
      */
-    public function push(MessageInterface $message, MiddlewarePushInterface|callable|array|string ...$middlewareDefinitions): MessageInterface;
+    public function push(MessageInterface $message): MessageInterface;
 
     /**
      * Handle all existing messages and exit

--- a/stubs/StubDelayMiddleware.php
+++ b/stubs/StubDelayMiddleware.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Queue\Stubs;
+
+use Yiisoft\Queue\Message\MessageInterface;
+use Yiisoft\Queue\Middleware\Push\Implementation\DelayMiddlewareInterface;
+use Yiisoft\Queue\Middleware\Push\MessageHandlerPushInterface;
+
+final class StubDelayMiddleware implements DelayMiddlewareInterface
+{
+    public function withDelay(float $seconds): DelayMiddlewareInterface
+    {
+        return $this;
+    }
+
+    public function processPush(MessageInterface $message, MessageHandlerPushInterface $handler): MessageInterface
+    {
+        return $handler->handlePush($message);
+    }
+}

--- a/stubs/StubQueue.php
+++ b/stubs/StubQueue.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Stubs;
 
-use Yiisoft\Queue\Adapter\AdapterInterface;
 use Yiisoft\Queue\MessageStatus;
 use Yiisoft\Queue\Message\MessageInterface;
-use Yiisoft\Queue\Middleware\Push\MiddlewarePushInterface;
 use Yiisoft\Queue\QueueInterface;
 
 /**
@@ -19,10 +17,8 @@ final class StubQueue implements QueueInterface
         private string $name = 'default',
     ) {}
 
-    public function push(
-        MessageInterface $message,
-        string|array|callable|MiddlewarePushInterface ...$middlewareDefinitions,
-    ): MessageInterface {
+    public function push(MessageInterface $message): MessageInterface
+    {
         return $message;
     }
 

--- a/tests/App/DummyQueue.php
+++ b/tests/App/DummyQueue.php
@@ -7,7 +7,6 @@ namespace Yiisoft\Queue\Tests\App;
 use Exception;
 use Yiisoft\Queue\MessageStatus;
 use Yiisoft\Queue\Message\MessageInterface;
-use Yiisoft\Queue\Middleware\Push\MiddlewarePushInterface;
 use Yiisoft\Queue\QueueInterface;
 
 final class DummyQueue implements QueueInterface
@@ -16,10 +15,8 @@ final class DummyQueue implements QueueInterface
         private readonly string $name,
     ) {}
 
-    public function push(
-        MessageInterface $message,
-        string|array|callable|MiddlewarePushInterface ...$middlewareDefinitions,
-    ): MessageInterface {
+    public function push(MessageInterface $message): MessageInterface
+    {
         return $message;
     }
 

--- a/tests/Integration/MiddlewareTest.php
+++ b/tests/Integration/MiddlewareTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Yiisoft\Injector\Injector;
+use Yiisoft\Queue\Stubs\StubDelayMiddleware;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Test\Support\Log\SimpleLogger;
 use Yiisoft\Queue\Cli\LoopInterface;
@@ -23,7 +24,6 @@ use Yiisoft\Queue\Middleware\FailureHandling\FailureMiddlewareDispatcher;
 use Yiisoft\Queue\Middleware\FailureHandling\Implementation\ExponentialDelayMiddleware;
 use Yiisoft\Queue\Middleware\FailureHandling\Implementation\SendAgainMiddleware;
 use Yiisoft\Queue\Middleware\FailureHandling\MiddlewareFactoryFailure;
-use Yiisoft\Queue\Middleware\Push\Implementation\DelayMiddlewareInterface;
 use Yiisoft\Queue\Middleware\Push\MiddlewareFactoryPush;
 use Yiisoft\Queue\Middleware\Push\PushMiddlewareDispatcher;
 use Yiisoft\Queue\Queue;
@@ -43,8 +43,6 @@ final class MiddlewareTest extends TestCase
             'channel 1',
             'channel 2',
             'channel 3',
-            'message 1',
-            'message 2',
         ];
 
         $pushMiddlewareDispatcher = new PushMiddlewareDispatcher(
@@ -72,11 +70,7 @@ final class MiddlewareTest extends TestCase
             ->withMiddlewaresAdded(new TestMiddleware('channel 3'));
 
         $message = new Message('test', ['initial']);
-        $messagePushed = $queue->push(
-            $message,
-            new TestMiddleware('message 1'),
-            new TestMiddleware('message 2'),
-        );
+        $messagePushed = $queue->push($message);
 
         self::assertEquals($stack, $messagePushed->getData());
     }
@@ -156,7 +150,7 @@ final class MiddlewareTest extends TestCase
                     1,
                     5,
                     2,
-                    $this->createMock(DelayMiddlewareInterface::class),
+                    new StubDelayMiddleware(),
                     $queue,
                 ),
             ],

--- a/tests/Unit/Debug/QueueCollectorTest.php
+++ b/tests/Unit/Debug/QueueCollectorTest.php
@@ -61,13 +61,11 @@ final class QueueCollectorTest extends AbstractCollectorTestCase
             'chan1' => [
                 [
                     'message' => $this->pushMessage,
-                    'middlewares' => [],
                 ],
             ],
             'chan2' => [
                 [
                     'message' => $this->pushMessage,
-                    'middlewares' => [],
                 ],
             ],
         ], $pushes);

--- a/tests/Unit/Debug/QueueDecoratorTest.php
+++ b/tests/Unit/Debug/QueueDecoratorTest.php
@@ -39,7 +39,7 @@ class QueueDecoratorTest extends TestCase
             $collector,
         );
 
-        $decorator->push($message, []);
+        $decorator->push($message);
     }
 
     public function testRun(): void

--- a/tests/Unit/Middleware/FailureHandling/Implementation/ExponentialDelayMiddlewareTest.php
+++ b/tests/Unit/Middleware/FailureHandling/Implementation/ExponentialDelayMiddlewareTest.php
@@ -12,8 +12,8 @@ use Yiisoft\Queue\Middleware\FailureHandling\FailureEnvelope;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 use Yiisoft\Queue\Middleware\FailureHandling\Implementation\ExponentialDelayMiddleware;
 use Yiisoft\Queue\Middleware\FailureHandling\MessageFailureHandlerInterface;
-use Yiisoft\Queue\Middleware\Push\Implementation\DelayMiddlewareInterface;
 use Yiisoft\Queue\QueueInterface;
+use Yiisoft\Queue\Stubs\StubDelayMiddleware;
 use Yiisoft\Queue\Tests\TestCase;
 
 use const PHP_INT_MAX;
@@ -119,7 +119,7 @@ class ExponentialDelayMiddlewareTest extends TestCase
     #[DataProvider('constructorRequirementsProvider')]
     public function testConstructorRequirements(bool $success, array $arguments): void
     {
-        $arguments[] = $this->createMock(DelayMiddlewareInterface::class);
+        $arguments[] = new StubDelayMiddleware();
         $arguments[] = $this->createMock(QueueInterface::class);
 
         if (!$success) {
@@ -141,7 +141,7 @@ class ExponentialDelayMiddlewareTest extends TestCase
             1,
             1,
             1,
-            $this->createMock(DelayMiddlewareInterface::class),
+            new StubDelayMiddleware(),
             $queue,
         );
         $nextHandler = $this->createMock(MessageFailureHandlerInterface::class);
@@ -175,7 +175,7 @@ class ExponentialDelayMiddlewareTest extends TestCase
             1,
             1,
             1,
-            $this->createMock(DelayMiddlewareInterface::class),
+            new StubDelayMiddleware(),
             $queue,
         );
         $nextHandler = $this->createMock(MessageFailureHandlerInterface::class);

--- a/tests/Unit/Middleware/FailureHandling/Implementation/SendAgainMiddlewareTest.php
+++ b/tests/Unit/Middleware/FailureHandling/Implementation/SendAgainMiddlewareTest.php
@@ -16,8 +16,8 @@ use Yiisoft\Queue\Middleware\FailureHandling\Implementation\ExponentialDelayMidd
 use Yiisoft\Queue\Middleware\FailureHandling\Implementation\SendAgainMiddleware;
 use Yiisoft\Queue\Middleware\FailureHandling\MessageFailureHandlerInterface;
 use Yiisoft\Queue\Middleware\FailureHandling\MiddlewareFailureInterface;
-use Yiisoft\Queue\Middleware\Push\Implementation\DelayMiddlewareInterface;
 use Yiisoft\Queue\QueueInterface;
+use Yiisoft\Queue\Stubs\StubDelayMiddleware;
 use Yiisoft\Queue\Tests\TestCase;
 
 class SendAgainMiddlewareTest extends TestCase
@@ -179,7 +179,7 @@ class SendAgainMiddlewareTest extends TestCase
                 self::EXPONENTIAL_STRATEGY_DELAY_INITIAL,
                 self::EXPONENTIAL_STRATEGY_DELAY_MAXIMUM,
                 self::EXPONENTIAL_STRATEGY_EXPONENT,
-                $this->createMock(DelayMiddlewareInterface::class),
+                new StubDelayMiddleware(),
                 $queue,
             ),
             default => throw new RuntimeException('Unknown strategy'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Tests pass?   | ✔️

