### PR TITLE
Introduce abstract `Message` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,71 @@ See the [adapter list](docs/guide/en/adapter-list.md) and follow the adapter-spe
 > In this mode messages are processed immediately in the same process, so it won't provide true
 > async execution, but the code stays the same when you switch to a real adapter.
 
-### 2. Configure the queue
+### 2. Prepare a message and handler
+
+Define a message class for the work to be done — a simple value object with typed properties:
+
+```php
+use Yiisoft\Queue\Message\Message;
+
+final class DownloadFileMessage extends Message
+{
+    public const TYPE = 'download-file';
+
+    public function __construct(
+        public readonly string $url,
+        public readonly string $destinationPath,
+    ) {}
+
+    public static function fromData(string $type, mixed $data): static
+    {
+        if ($type !== self::TYPE) {
+            throw new \InvalidArgumentException("Expected type \"" . self::TYPE . "\", got \"$type\".");
+        }
+        if (!is_array($data)
+            || !is_string($data['url'] ?? null)
+            || !is_string($data['destinationPath'] ?? null)
+        ) {
+            throw new \InvalidArgumentException('Invalid data for ' . self::class . '.');
+        }
+        return new self($data['url'], $data['destinationPath']);
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function getData(): array
+    {
+        return ['url' => $this->url, 'destinationPath' => $this->destinationPath];
+    }
+}
+```
+
+Then create a handler that processes it:
+
+```php
+use Yiisoft\Queue\Message\MessageInterface;
+use Yiisoft\Queue\Message\MessageHandlerInterface;
+
+final readonly class RemoteFileHandler implements MessageHandlerInterface
+{
+    public function __construct(
+        private FileDownloader $downloader,
+        private FileProcessor $processor,
+    ) {}
+
+    public function handle(MessageInterface $message): void
+    {
+        assert($message instanceof DownloadFileMessage);
+        $localPath = $this->downloader->download($message->url, $message->destinationPath);
+        $this->processor->process($localPath);
+    }
+}
+```
+
+### 3. Configure the queue
 
 #### Configuration with [yiisoft/config](https://github.com/yiisoft/config)
 
@@ -57,7 +121,7 @@ Minimal configuration example:
 return [
     'yiisoft/queue' => [
         'handlers' => [
-            'message-type' => [FooHandler::class, 'handle'],
+            DownloadFileMessage::TYPE => RemoteFileHandler::class,
         ],
     ],
 ];
@@ -69,49 +133,20 @@ return [
 
 For setting up all classes manually, see the [Manual configuration](docs/guide/en/configuration-manual.md) guide.
 
-### 3. Prepare a handler
-
-You need to create a handler class that will process the queue messages. The most simple way is to implement the `MessageHandlerInterface`. Let's create an example for remote file processing:
-
-```php
-use Yiisoft\Queue\Message\MessageInterface;
-use Yiisoft\Queue\Message\MessageHandlerInterface;
-
-final readonly class RemoteFileHandler implements MessageHandlerInterface
-{
-    // These dependencies will be resolved on handler creation by the DI container
-    public function __construct(
-        private FileDownloader $downloader,
-        private FileProcessor $processor,
-    ) {}
-
-    // Every received message will be processed by this method
-    public function handle(MessageInterface $downloadMessage): void
-    {
-        $url = $downloadMessage->getData()['url'];
-        $localPath = $this->downloader->download($url);
-        $this->processor->process($localPath);
-    }
-}
-```
-
 ### 4. Send (produce/push) a message to a queue
 
-To send a message to the queue, you need to get the queue instance and call the `push()` method. Typically, with Yii Framework you'll get a `Queue` instance as a dependency of a service.
+To send a message to the queue, get the queue instance and call `push()`. Typically the queue is injected as a dependency:
 
 ```php
-
-final readonly class Foo {
+final readonly class Foo
+{
     public function __construct(private QueueInterface $queue) {}
 
     public function bar(): void
     {
-        $this->queue->push(new Message(
-            // The first parameter is the message type used to resolve the handler which will process the message
-            RemoteFileHandler::class,
-            // The second parameter is the data that will be passed to the handler.
-            // It should be serializable to JSON format
-            ['url' => 'https://example.com/file-path.csv'],
+        $this->queue->push(new DownloadFileMessage(
+            url: 'https://example.com/file-path.csv',
+            destinationPath: '/tmp/file-path.csv',
         ));
     }
 }

--- a/docs/guide/en/configuration-manual.md
+++ b/docs/guide/en/configuration-manual.md
@@ -35,8 +35,7 @@ $logger = new NullLogger(); // replace with your PSR-3 logger in production
 
 // Define message handlers
 $handlers = [
-    'file-download' => [FileDownloader::class, 'handle'],
-    FileDownloader::class => [FileDownloader::class, 'handle'],
+    DownloadFileMessage::TYPE => [FileDownloader::class, 'handle'],
 ];
 
 $callableFactory = new CallableFactory($container);
@@ -79,7 +78,7 @@ $queue = new Queue(
 );
 
 // Now you can push messages
-$message = new \Yiisoft\Queue\Message\GenericMessage('file-download', ['url' => 'https://example.com/file.pdf']);
+$message = new DownloadFileMessage(url: 'https://example.com/file.pdf', destinationPath: '/tmp/file.pdf');
 $queue->push($message);
 ```
 

--- a/docs/guide/en/configuration-manual.md
+++ b/docs/guide/en/configuration-manual.md
@@ -79,7 +79,7 @@ $queue = new Queue(
 );
 
 // Now you can push messages
-$message = new \Yiisoft\Queue\Message\Message('file-download', ['url' => 'https://example.com/file.pdf']);
+$message = new \Yiisoft\Queue\Message\SimpleMessage('file-download', ['url' => 'https://example.com/file.pdf']);
 $queue->push($message);
 ```
 

--- a/docs/guide/en/configuration-manual.md
+++ b/docs/guide/en/configuration-manual.md
@@ -79,7 +79,7 @@ $queue = new Queue(
 );
 
 // Now you can push messages
-$message = new \Yiisoft\Queue\Message\SimpleMessage('file-download', ['url' => 'https://example.com/file.pdf']);
+$message = new \Yiisoft\Queue\Message\GenericMessage('file-download', ['url' => 'https://example.com/file.pdf']);
 $queue->push($message);
 ```
 

--- a/docs/guide/en/message-handler-advanced.md
+++ b/docs/guide/en/message-handler-advanced.md
@@ -17,9 +17,9 @@ Handler definitions are configured in:
 Use a short stable message type when pushing a `Message` instead of a PHP class name:
 
 ```php
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 
-new Message('send-email', ['data' => '...']); // "send-email" is the message type here
+new SimpleMessage('send-email', ['data' => '...']); // "send-email" is the message type here
 ```
 
 **Config**:

--- a/docs/guide/en/message-handler-advanced.md
+++ b/docs/guide/en/message-handler-advanced.md
@@ -14,12 +14,51 @@ Handler definitions are configured in:
 
 ### Handlers mapped by short message type
 
-Use a short stable message type when pushing a `Message` instead of a PHP class name:
+Use a short stable message type instead of a PHP class name. Define a dedicated message class where `getType()` returns that type:
 
 ```php
-use Yiisoft\Queue\Message\GenericMessage;
+use Yiisoft\Queue\Message\Message;
 
-new GenericMessage('send-email', ['data' => '...']); // "send-email" is the message type here
+final class SendEmailMessage extends Message
+{
+    public const TYPE = 'send-email';
+
+    public function __construct(
+        public readonly string $to,
+        public readonly string $subject,
+        public readonly string $body,
+    ) {}
+
+    public static function fromData(string $type, mixed $data): static
+    {
+        if ($type !== self::TYPE) {
+            throw new \InvalidArgumentException("Expected type \"" . self::TYPE . "\", got \"$type\".");
+        }
+        if (!is_array($data)
+            || !is_string($data['to'] ?? null)
+            || !is_string($data['subject'] ?? null)
+            || !is_string($data['body'] ?? null)
+        ) {
+            throw new \InvalidArgumentException('Invalid data for ' . self::class . '.');
+        }
+        return new self($data['to'], $data['subject'], $data['body']);
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function getData(): array
+    {
+        return ['to' => $this->to, 'subject' => $this->subject, 'body' => $this->body];
+    }
+}
+```
+
+```php
+new SendEmailMessage('user@example.com', 'Welcome', 'Thank you for registering.');
+// getType() returns "send-email" — used by the worker to look up the handler
 ```
 
 **Config**:

--- a/docs/guide/en/message-handler-advanced.md
+++ b/docs/guide/en/message-handler-advanced.md
@@ -14,7 +14,8 @@ Handler definitions are configured in:
 
 ### Handlers mapped by short message type
 
-Use a short stable message type instead of a PHP class name. Define a dedicated message class where `getType()` returns that type:
+Use a short stable message type instead of a PHP class name. That decoupling would allow you to refactor the code and handle the message with external handler.
+Define a dedicated message class where `getType()` returns that type:
 
 ```php
 use Yiisoft\Queue\Message\Message;

--- a/docs/guide/en/message-handler-advanced.md
+++ b/docs/guide/en/message-handler-advanced.md
@@ -17,9 +17,9 @@ Handler definitions are configured in:
 Use a short stable message type when pushing a `Message` instead of a PHP class name:
 
 ```php
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 
-new SimpleMessage('send-email', ['data' => '...']); // "send-email" is the message type here
+new GenericMessage('send-email', ['data' => '...']); // "send-email" is the message type here
 ```
 
 **Config**:

--- a/docs/guide/en/message-handler.md
+++ b/docs/guide/en/message-handler.md
@@ -13,7 +13,34 @@ If your handler implements `Yiisoft\Queue\Message\MessageHandlerInterface`, you 
 **Message**:
 
 ```php
-new \Yiisoft\Queue\Message\GenericMessage(\App\Queue\RemoteFileHandler::class, ['url' => '...']);
+use Yiisoft\Queue\Message\Message;
+
+final class RemoteFileMessage extends Message
+{
+    public function __construct(public readonly string $url) {}
+
+    public static function fromData(string $type, mixed $data): static
+    {
+        if (!is_array($data) || !is_string($data['url'] ?? null)) {
+            throw new \InvalidArgumentException('Invalid data for ' . self::class . '.');
+        }
+        return new self($data['url']);
+    }
+
+    public function getType(): string
+    {
+        return \App\Queue\RemoteFileHandler::class;
+    }
+
+    public function getData(): array
+    {
+        return ['url' => $this->url];
+    }
+}
+```
+
+```php
+new RemoteFileMessage('https://...');
 ```
 
 **Handler**:

--- a/docs/guide/en/message-handler.md
+++ b/docs/guide/en/message-handler.md
@@ -13,7 +13,7 @@ If your handler implements `Yiisoft\Queue\Message\MessageHandlerInterface`, you 
 **Message**:
 
 ```php
-new \Yiisoft\Queue\Message\SimpleMessage(\App\Queue\RemoteFileHandler::class, ['url' => '...']);
+new \Yiisoft\Queue\Message\GenericMessage(\App\Queue\RemoteFileHandler::class, ['url' => '...']);
 ```
 
 **Handler**:

--- a/docs/guide/en/message-handler.md
+++ b/docs/guide/en/message-handler.md
@@ -13,7 +13,7 @@ If your handler implements `Yiisoft\Queue\Message\MessageHandlerInterface`, you 
 **Message**:
 
 ```php
-new \Yiisoft\Queue\Message\Message(\App\Queue\RemoteFileHandler::class, ['url' => '...']);
+new \Yiisoft\Queue\Message\SimpleMessage(\App\Queue\RemoteFileHandler::class, ['url' => '...']);
 ```
 
 **Handler**:

--- a/docs/guide/en/messages-and-handlers.md
+++ b/docs/guide/en/messages-and-handlers.md
@@ -11,11 +11,18 @@ This separation is intentional and important. Understanding it will save you fro
 
 A *producer* creates messages and pushes them onto the queue. A *consumer* (worker) pulls messages from the queue and invokes the matching handler.
 
-```
-Producer side                       Consumer side
-──────────────────────────────      ──────────────────────────────────
-new SendEmailMessage(…)        →→→  Worker resolves handler → handles
-         (payload only)                      (logic only)
+```mermaid
+flowchart LR
+      subgraph Producer["Producer side"]
+          Message["new SendEmailMessage(...)\n(payload only)"]
+      end
+
+      subgraph Consumer["Consumer side"]
+          Worker["Worker resolves handler"]
+          Handler["Handler handles\n(logic only)"]
+      end
+
+      Message --> Worker --> Handler
 ```
 
 The producer only needs to know the message type and its data. It does not need to know anything about how the message will be processed, or even in which application.

--- a/docs/guide/en/messages-and-handlers.md
+++ b/docs/guide/en/messages-and-handlers.md
@@ -12,10 +12,10 @@ This separation is intentional and important. Understanding it will save you fro
 A *producer* creates messages and pushes them onto the queue. A *consumer* (worker) pulls messages from the queue and invokes the matching handler.
 
 ```
-Producer side                      Consumer side
-─────────────────────────────      ──────────────────────────────────
-new Message('send-email', …)  →→→  Worker resolves handler → handles
-         (payload only)                     (logic only)
+Producer side                       Consumer side
+──────────────────────────────      ──────────────────────────────────
+new SendEmailMessage(…)        →→→  Worker resolves handler → handles
+         (payload only)                      (logic only)
 ```
 
 The producer only needs to know the message type and its data. It does not need to know anything about how the message will be processed, or even in which application.
@@ -30,21 +30,61 @@ This means the producer and consumer can be:
 
 ## Message: payload only
 
-A message carries just enough data to perform the work:
+A message carries just enough data to perform the work. Defining a dedicated class for each message type makes your code
+self-documenting and type-safe:
 
 ```php
-new \Yiisoft\Queue\Message\GenericMessage('send-email', [
-    'to'      => 'user@example.com',
-    'subject' => 'Welcome',
-]);
+use Yiisoft\Queue\Message\Message;
+
+final class SendEmailMessage extends Message
+{
+    public const TYPE = 'send-email';
+
+    public function __construct(
+        public readonly string $to,
+        public readonly string $subject,
+        public readonly string $body,
+    ) {}
+
+    public static function fromData(string $type, mixed $data): static
+    {
+        if ($type !== self::TYPE) {
+            throw new \InvalidArgumentException("Expected type \"" . self::TYPE . "\", got \"$type\".");
+        }
+        if (!is_array($data)
+            || !is_string($data['to'] ?? null)
+            || !is_string($data['subject'] ?? null)
+            || !is_string($data['body'] ?? null)
+        ) {
+            throw new \InvalidArgumentException('Invalid data for ' . self::class . '.');
+        }
+        return new self($data['to'], $data['subject'], $data['body']);
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function getData(): array
+    {
+        return ['to' => $this->to, 'subject' => $this->subject, 'body' => $this->body];
+    }
+}
+```
+
+Usage:
+
+```php
+new SendEmailMessage('user@example.com', 'Welcome', 'Thank you for registering.');
 ```
 
 The message has:
 
 - A **message type** — a string used by the worker to look up the correct handler.
-- A **data payload** — arbitrary data the handler needs. Must be serializable.
+- A **data payload** — typed properties serialized to JSON via `getData()`. Must be JSON-encodable.
 
-The message has no methods, no business logic, no dependencies. It is a value object — a data wrapper.
+The message has no business logic, no dependencies. It is a value object — a typed data wrapper.
 
 ## Handler: logic only
 
@@ -57,8 +97,8 @@ final class SendEmailHandler implements \Yiisoft\Queue\Message\MessageHandlerInt
 
     public function handle(\Yiisoft\Queue\Message\MessageInterface $message): void
     {
-        $data = $message->getData();
-        $this->mailer->send($data['to'], $data['subject']);
+        assert($message instanceof SendEmailMessage);
+        $this->mailer->send($message->to, $message->subject, $message->body);
     }
 }
 ```

--- a/docs/guide/en/messages-and-handlers.md
+++ b/docs/guide/en/messages-and-handlers.md
@@ -30,7 +30,8 @@ This means the producer and consumer can be:
 
 ## Message: payload only
 
-A message carries just enough data to perform the work. Defining a dedicated class for each message type makes your code
+A message carries just enough data to perform the work. Usually data has some parameters but not the full context to process. Getting full context is better to be moved to the handler unless processing is done in another application that doesn't have access to data storage. 
+Defining a dedicated class for each message type makes your code
 self-documenting and type-safe:
 
 ```php

--- a/docs/guide/en/messages-and-handlers.md
+++ b/docs/guide/en/messages-and-handlers.md
@@ -33,7 +33,7 @@ This means the producer and consumer can be:
 A message carries just enough data to perform the work:
 
 ```php
-new \Yiisoft\Queue\Message\Message('send-email', [
+new \Yiisoft\Queue\Message\SimpleMessage('send-email', [
     'to'      => 'user@example.com',
     'subject' => 'Welcome',
 ]);

--- a/docs/guide/en/messages-and-handlers.md
+++ b/docs/guide/en/messages-and-handlers.md
@@ -33,7 +33,7 @@ This means the producer and consumer can be:
 A message carries just enough data to perform the work:
 
 ```php
-new \Yiisoft\Queue\Message\SimpleMessage('send-email', [
+new \Yiisoft\Queue\Message\GenericMessage('send-email', [
     'to'      => 'user@example.com',
     'subject' => 'Welcome',
 ]);

--- a/docs/guide/en/queue-names.md
+++ b/docs/guide/en/queue-names.md
@@ -68,7 +68,7 @@ Pushing a message via DI:
 
 ```php
 use Yiisoft\Queue\QueueInterface;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 
 final readonly class SendWelcomeEmail
 {
@@ -78,7 +78,7 @@ final readonly class SendWelcomeEmail
 
     public function run(string $email): void
     {
-        $this->queue->push(new Message('send-email', ['to' => $email]));
+        $this->queue->push(new SimpleMessage('send-email', ['to' => $email]));
     }
 }
 ```
@@ -105,7 +105,7 @@ If you have multiple queue names, inject `QueueProviderInterface` and call `get(
 
 ```php
 use Yiisoft\Queue\Provider\QueueProviderInterface;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 
 final readonly class SendTransactionalEmail
 {
@@ -117,7 +117,7 @@ final readonly class SendTransactionalEmail
     {
         $this->queueProvider
             ->get('emails')
-            ->push(new Message('send-email', ['to' => $email]));
+            ->push(new SimpleMessage('send-email', ['to' => $email]));
     }
 }
 ```

--- a/docs/guide/en/queue-names.md
+++ b/docs/guide/en/queue-names.md
@@ -68,7 +68,6 @@ Pushing a message via DI:
 
 ```php
 use Yiisoft\Queue\QueueInterface;
-use Yiisoft\Queue\Message\GenericMessage;
 
 final readonly class SendWelcomeEmail
 {
@@ -78,7 +77,7 @@ final readonly class SendWelcomeEmail
 
     public function run(string $email): void
     {
-        $this->queue->push(new GenericMessage('send-email', ['to' => $email]));
+        $this->queue->push(new SendEmailMessage(to: $email, subject: 'Welcome!', body: 'Thank you for registering.'));
     }
 }
 ```
@@ -105,7 +104,6 @@ If you have multiple queue names, inject `QueueProviderInterface` and call `get(
 
 ```php
 use Yiisoft\Queue\Provider\QueueProviderInterface;
-use Yiisoft\Queue\Message\GenericMessage;
 
 final readonly class SendTransactionalEmail
 {
@@ -117,7 +115,7 @@ final readonly class SendTransactionalEmail
     {
         $this->queueProvider
             ->get('emails')
-            ->push(new GenericMessage('send-email', ['to' => $email]));
+            ->push(new SendEmailMessage(to: $email, subject: 'Welcome!', body: 'Thank you for registering.'));
     }
 }
 ```

--- a/docs/guide/en/queue-names.md
+++ b/docs/guide/en/queue-names.md
@@ -68,7 +68,7 @@ Pushing a message via DI:
 
 ```php
 use Yiisoft\Queue\QueueInterface;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 
 final readonly class SendWelcomeEmail
 {
@@ -78,7 +78,7 @@ final readonly class SendWelcomeEmail
 
     public function run(string $email): void
     {
-        $this->queue->push(new SimpleMessage('send-email', ['to' => $email]));
+        $this->queue->push(new GenericMessage('send-email', ['to' => $email]));
     }
 }
 ```
@@ -105,7 +105,7 @@ If you have multiple queue names, inject `QueueProviderInterface` and call `get(
 
 ```php
 use Yiisoft\Queue\Provider\QueueProviderInterface;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 
 final readonly class SendTransactionalEmail
 {
@@ -117,7 +117,7 @@ final readonly class SendTransactionalEmail
     {
         $this->queueProvider
             ->get('emails')
-            ->push(new SimpleMessage('send-email', ['to' => $email]));
+            ->push(new GenericMessage('send-email', ['to' => $email]));
     }
 }
 ```

--- a/docs/guide/en/usage.md
+++ b/docs/guide/en/usage.md
@@ -2,13 +2,48 @@
 
 ## Usage
 
-For example, if you need to download and save a file, you can create a message like this:
+For example, if you need to download and save a file, define a message class and push it:
 
 ```php
-$message = new \Yiisoft\Queue\Message\GenericMessage(
-    RemoteFileHandler::class,
-    ['url' => $url, 'destinationFile' => $filename]
-);
+use Yiisoft\Queue\Message\Message;
+
+final class DownloadFileMessage extends Message
+{
+    public const TYPE = 'download-file';
+
+    public function __construct(
+        public readonly string $url,
+        public readonly string $destinationPath,
+    ) {}
+
+    public static function fromData(string $type, mixed $data): static
+    {
+        if ($type !== self::TYPE) {
+            throw new \InvalidArgumentException("Expected type \"" . self::TYPE . "\", got \"$type\".");
+        }
+        if (!is_array($data)
+            || !is_string($data['url'] ?? null)
+            || !is_string($data['destinationPath'] ?? null)
+        ) {
+            throw new \InvalidArgumentException('Invalid data for ' . self::class . '.');
+        }
+        return new self($data['url'], $data['destinationPath']);
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function getData(): array
+    {
+        return ['url' => $this->url, 'destinationPath' => $this->destinationPath];
+    }
+}
+```
+
+```php
+$message = new DownloadFileMessage(url: $url, destinationPath: $filename);
 ```
 
 Here's how to push a message to the queue:

--- a/docs/guide/en/usage.md
+++ b/docs/guide/en/usage.md
@@ -5,7 +5,7 @@
 For example, if you need to download and save a file, you can create a message like this:
 
 ```php
-$message = new \Yiisoft\Queue\Message\SimpleMessage(
+$message = new \Yiisoft\Queue\Message\GenericMessage(
     RemoteFileHandler::class,
     ['url' => $url, 'destinationFile' => $filename]
 );

--- a/docs/guide/en/usage.md
+++ b/docs/guide/en/usage.md
@@ -5,7 +5,7 @@
 For example, if you need to download and save a file, you can create a message like this:
 
 ```php
-$message = new \Yiisoft\Queue\Message\Message(
+$message = new \Yiisoft\Queue\Message\SimpleMessage(
     RemoteFileHandler::class,
     ['url' => $url, 'destinationFile' => $filename]
 );

--- a/src/Message/Envelope.php
+++ b/src/Message/Envelope.php
@@ -25,6 +25,11 @@ abstract class Envelope implements MessageInterface
         $this->message = $message;
     }
 
+    /**
+     * Envelopes cannot be created from raw data. Use {@see fromMessage()} to wrap an existing message instead.
+     *
+     * @throws LogicException Always, since this method is not supported for envelopes.
+     */
     final public static function fromData(string $type, mixed $data): static
     {
         throw new LogicException(
@@ -32,6 +37,11 @@ abstract class Envelope implements MessageInterface
         );
     }
 
+    /**
+     * Creates an envelope for the given message, restoring the envelope's own parameters from the message metadata.
+     *
+     * @param MessageInterface $message The message to create an envelope for.
+     */
     abstract public static function fromMessage(MessageInterface $message): static;
 
     final public function getMessage(): MessageInterface

--- a/src/Message/Envelope.php
+++ b/src/Message/Envelope.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Message;
 
+use LogicException;
+
 abstract class Envelope implements MessageInterface
 {
     /**
@@ -23,9 +25,11 @@ abstract class Envelope implements MessageInterface
         $this->message = $message;
     }
 
-    final public static function fromData(string $type, mixed $data, array $metadata = []): static
+    final public static function fromData(string $type, mixed $data): static
     {
-        return static::fromMessage(Message::fromData($type, $data, $metadata));
+        throw new LogicException(
+            'Envelopes cannot be created via "fromData()". Wrap an existing "MessageInterface" instance instead.',
+        );
     }
 
     abstract public static function fromMessage(MessageInterface $message): static;
@@ -48,5 +52,10 @@ abstract class Envelope implements MessageInterface
     final public function getMetadata(): array
     {
         return $this->metadata;
+    }
+
+    final public function withMetadata(array $metadata): static
+    {
+        return static::fromMessage($this->message->withMetadata($metadata));
     }
 }

--- a/src/Message/GenericMessage.php
+++ b/src/Message/GenericMessage.php
@@ -4,27 +4,46 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Message;
 
+/**
+ * A general-purpose immutable {@see MessageInterface} implementation that holds a message type and its payload data.
+ *
+ * Prefer creating custom message classes that better express your domain.
+ */
 final class GenericMessage extends Message
 {
     /**
      * @param string $type A message type used to resolve the handler.
-     * @param mixed $data Message data, encodable by a queue adapter
+     * @param mixed $data Message payload data.
      */
     public function __construct(
         private readonly string $type,
         private readonly mixed $data,
     ) {}
 
+    /**
+     * Creates a new message instance from the given type and payload data.
+     *
+     * @param string $type A message type used to resolve the handler.
+     * @param mixed $data Message payload data.
+     *
+     * @return MessageInterface The created message instance.
+     */
     public static function fromData(string $type, mixed $data): MessageInterface
     {
         return new self($type, $data);
     }
 
+    /**
+     * Returns the message type used to resolve the handler.
+     */
     public function getType(): string
     {
         return $this->type;
     }
 
+    /**
+     * Returns the message payload data.
+     */
     public function getData(): mixed
     {
         return $this->data;

--- a/src/Message/GenericMessage.php
+++ b/src/Message/GenericMessage.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Message;
 
-final class SimpleMessage extends Message
+final class GenericMessage extends Message
 {
     /**
      * @param string $type A message type used to resolve the handler.

--- a/src/Message/JsonMessageSerializer.php
+++ b/src/Message/JsonMessageSerializer.php
@@ -54,10 +54,10 @@ final class JsonMessageSerializer implements MessageSerializerInterface
             throw new InvalidArgumentException('Metadata must be an array. Got ' . get_debug_type($meta) . '.');
         }
 
-        $class = $meta['message-class'] ?? SimpleMessage::class;
+        $class = $meta['message-class'] ?? GenericMessage::class;
         // Don't check subclasses when it's a default class: that's faster
-        if ($class !== SimpleMessage::class && !is_subclass_of($class, MessageInterface::class)) {
-            $class = SimpleMessage::class;
+        if ($class !== GenericMessage::class && !is_subclass_of($class, MessageInterface::class)) {
+            $class = GenericMessage::class;
         }
 
         /**

--- a/src/Message/JsonMessageSerializer.php
+++ b/src/Message/JsonMessageSerializer.php
@@ -54,15 +54,15 @@ final class JsonMessageSerializer implements MessageSerializerInterface
             throw new InvalidArgumentException('Metadata must be an array. Got ' . get_debug_type($meta) . '.');
         }
 
-        $class = $meta['message-class'] ?? Message::class;
+        $class = $meta['message-class'] ?? SimpleMessage::class;
         // Don't check subclasses when it's a default class: that's faster
-        if ($class !== Message::class && !is_subclass_of($class, MessageInterface::class)) {
-            $class = Message::class;
+        if ($class !== SimpleMessage::class && !is_subclass_of($class, MessageInterface::class)) {
+            $class = SimpleMessage::class;
         }
 
         /**
          * @var class-string<MessageInterface> $class
          */
-        return $class::fromData($type, $payload['data'] ?? null, $meta);
+        return $class::fromData($type, $payload['data'] ?? null)->withMetadata($meta);
     }
 }

--- a/src/Message/Message.php
+++ b/src/Message/Message.php
@@ -18,10 +18,8 @@ abstract class Message implements MessageInterface
 
     final public function withMetadata(array $metadata): static
     {
-        $this->metadata = $metadata;
-        return $this;
-//        $new = clone $this;
-//        $new->metadata = $metadata;
-//        return $new;
+        $new = clone $this;
+        $new->metadata = $metadata;
+        return $new;
     }
 }

--- a/src/Message/Message.php
+++ b/src/Message/Message.php
@@ -4,38 +4,22 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Message;
 
-final class Message implements MessageInterface
+abstract class Message implements MessageInterface
 {
     /**
-     * @param string $type A message type used to resolve the handler.
-     * @param mixed $data Message data, encodable by a queue adapter
-     * @param array $metadata Message metadata, encodable by a queue adapter
-     *
-     * @psalm-param array<string, mixed> $metadata
+     * @psalm-var array<string, mixed>
      */
-    public function __construct(
-        private readonly string $type,
-        private readonly mixed $data,
-        private array $metadata = [],
-    ) {}
+    private array $metadata = [];
 
-    public static function fromData(string $type, mixed $data, array $metadata = []): MessageInterface
-    {
-        return new self($type, $data, $metadata);
-    }
-
-    public function getType(): string
-    {
-        return $this->type;
-    }
-
-    public function getData(): mixed
-    {
-        return $this->data;
-    }
-
-    public function getMetadata(): array
+    final public function getMetadata(): array
     {
         return $this->metadata;
+    }
+
+    final public function withMetadata(array $metadata): static
+    {
+        $new = clone $this;
+        $new->metadata = $metadata;
+        return $new;
     }
 }

--- a/src/Message/Message.php
+++ b/src/Message/Message.php
@@ -18,8 +18,10 @@ abstract class Message implements MessageInterface
 
     final public function withMetadata(array $metadata): static
     {
-        $new = clone $this;
-        $new->metadata = $metadata;
-        return $new;
+        $this->metadata = $metadata;
+        return $this;
+//        $new = clone $this;
+//        $new->metadata = $metadata;
+//        return $new;
     }
 }

--- a/src/Message/MessageInterface.php
+++ b/src/Message/MessageInterface.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Queue\Message;
 
 interface MessageInterface
 {
-    public static function fromData(string $type, mixed $data, array $metadata = []): self;
+    public static function fromData(string $type, mixed $data): self;
 
     /**
      * Returns message type.
@@ -24,4 +24,11 @@ interface MessageInterface
      * @return array<string, mixed>
      */
     public function getMetadata(): array;
+
+    /**
+     * Returns a new instance with the given message metadata.
+     *
+     * @param array<string, mixed> $metadata
+     */
+    public function withMetadata(array $metadata): static;
 }

--- a/src/Message/SimpleMessage.php
+++ b/src/Message/SimpleMessage.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Queue\Message;
+
+final class SimpleMessage extends Message
+{
+    /**
+     * @param string $type A message type used to resolve the handler.
+     * @param mixed $data Message data, encodable by a queue adapter
+     */
+    public function __construct(
+        private readonly string $type,
+        private readonly mixed $data,
+    ) {}
+
+    public static function fromData(string $type, mixed $data): MessageInterface
+    {
+        return new self($type, $data);
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getData(): mixed
+    {
+        return $this->data;
+    }
+}

--- a/tests/Benchmark/MetadataBench.php
+++ b/tests/Benchmark/MetadataBench.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Queue\Tests\Benchmark;
 use Generator;
 use PhpBench\Attributes\ParamProviders;
 use Yiisoft\Queue\Message\IdEnvelope;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureEnvelope;
 
@@ -18,7 +18,7 @@ final class MetadataBench
      */
     public function benchArrayRead(): void
     {
-        $message = (new SimpleMessage('foo', 'bar'))->withMetadata(['id' => 1]);
+        $message = (new GenericMessage('foo', 'bar'))->withMetadata(['id' => 1]);
         $id = $message->getMetadata()['id'];
     }
 
@@ -27,7 +27,7 @@ final class MetadataBench
      */
     public function benchEnvelopeRead(): void
     {
-        $message = new IdEnvelope(new SimpleMessage('foo', 'bar'), 1);
+        $message = new IdEnvelope(new GenericMessage('foo', 'bar'), 1);
         $id = $message->getId();
     }
 
@@ -36,14 +36,14 @@ final class MetadataBench
      */
     public function benchEnvelopeReadRestored(): void
     {
-        $message = IdEnvelope::fromMessage((new SimpleMessage('foo', 'bar'))->withMetadata(['id' => 1]));
+        $message = IdEnvelope::fromMessage((new GenericMessage('foo', 'bar'))->withMetadata(['id' => 1]));
         $id = $message->getId();
     }
 
     public function provideEnvelopeStack(): Generator
     {
         $config = [1 => 'one', 5 => 'five', 15 => 'fifteen'];
-        $message = new IdEnvelope(new SimpleMessage('foo', 'bar'), 1);
+        $message = new IdEnvelope(new GenericMessage('foo', 'bar'), 1);
 
         for ($i = 1; $i <= max(...array_keys($config)); $i++) {
             if (isset($config[$i])) {
@@ -79,7 +79,7 @@ final class MetadataBench
     #[ParamProviders('provideEnvelopeStackCounts')]
     public function benchEnvelopeStackCreation(array $params): void
     {
-        $message = new SimpleMessage('foo', 'bar');
+        $message = new GenericMessage('foo', 'bar');
         for ($i = 0; $i < $params[0]; $i++) {
             $message = new FailureEnvelope($message, ["fail$i" => "fail$i"]);
         }
@@ -97,6 +97,6 @@ final class MetadataBench
         for ($i = 0; $i < $params[0]; $i++) {
             $metadata['failure-meta']["fail$i"] = "fail$i";
         }
-        $message = (new SimpleMessage('foo', 'bar'))->withMetadata($metadata);
+        $message = (new GenericMessage('foo', 'bar'))->withMetadata($metadata);
     }
 }

--- a/tests/Benchmark/MetadataBench.php
+++ b/tests/Benchmark/MetadataBench.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Queue\Tests\Benchmark;
 use Generator;
 use PhpBench\Attributes\ParamProviders;
 use Yiisoft\Queue\Message\IdEnvelope;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureEnvelope;
 
@@ -18,7 +18,7 @@ final class MetadataBench
      */
     public function benchArrayRead(): void
     {
-        $message = new Message('foo', 'bar', ['id' => 1]);
+        $message = (new SimpleMessage('foo', 'bar'))->withMetadata(['id' => 1]);
         $id = $message->getMetadata()['id'];
     }
 
@@ -27,7 +27,7 @@ final class MetadataBench
      */
     public function benchEnvelopeRead(): void
     {
-        $message = new IdEnvelope(new Message('foo', 'bar'), 1);
+        $message = new IdEnvelope(new SimpleMessage('foo', 'bar'), 1);
         $id = $message->getId();
     }
 
@@ -36,14 +36,14 @@ final class MetadataBench
      */
     public function benchEnvelopeReadRestored(): void
     {
-        $message = IdEnvelope::fromMessage(new Message('foo', 'bar', ['id' => 1]));
+        $message = IdEnvelope::fromMessage((new SimpleMessage('foo', 'bar'))->withMetadata(['id' => 1]));
         $id = $message->getId();
     }
 
     public function provideEnvelopeStack(): Generator
     {
         $config = [1 => 'one', 5 => 'five', 15 => 'fifteen'];
-        $message = new IdEnvelope(new Message('foo', 'bar'), 1);
+        $message = new IdEnvelope(new SimpleMessage('foo', 'bar'), 1);
 
         for ($i = 1; $i <= max(...array_keys($config)); $i++) {
             if (isset($config[$i])) {
@@ -79,7 +79,7 @@ final class MetadataBench
     #[ParamProviders('provideEnvelopeStackCounts')]
     public function benchEnvelopeStackCreation(array $params): void
     {
-        $message = new Message('foo', 'bar');
+        $message = new SimpleMessage('foo', 'bar');
         for ($i = 0; $i < $params[0]; $i++) {
             $message = new FailureEnvelope($message, ["fail$i" => "fail$i"]);
         }
@@ -97,6 +97,6 @@ final class MetadataBench
         for ($i = 0; $i < $params[0]; $i++) {
             $metadata['failure-meta']["fail$i"] = "fail$i";
         }
-        $message = new Message('foo', 'bar', $metadata);
+        $message = (new SimpleMessage('foo', 'bar'))->withMetadata($metadata);
     }
 }

--- a/tests/Benchmark/QueueBench.php
+++ b/tests/Benchmark/QueueBench.php
@@ -11,7 +11,7 @@ use Yiisoft\Injector\Injector;
 use Yiisoft\Queue\Cli\SimpleLoop;
 use Yiisoft\Queue\Message\IdEnvelope;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareDispatcher;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareFactory;
@@ -66,11 +66,11 @@ final class QueueBench
 
     public function providePush(): Generator
     {
-        yield 'simple' => ['message' => new Message('foo', 'bar')];
+        yield 'simple' => ['message' => new SimpleMessage('foo', 'bar')];
         yield 'with envelopes' => [
             'message' => new FailureEnvelope(
                 new IdEnvelope(
-                    new Message('foo', 'bar'),
+                    new SimpleMessage('foo', 'bar'),
                     'test id',
                 ),
                 ['failure-1' => ['a', 'b', 'c']],
@@ -86,12 +86,12 @@ final class QueueBench
 
     public function provideConsume(): Generator
     {
-        yield 'simple mapping' => ['message' => $this->serializer->serialize(new Message('foo', 'bar'))];
+        yield 'simple mapping' => ['message' => $this->serializer->serialize(new SimpleMessage('foo', 'bar'))];
         yield 'with envelopes mapping' => [
             'message' => $this->serializer->serialize(
                 new FailureEnvelope(
                     new IdEnvelope(
-                        new Message('foo', 'bar'),
+                        new SimpleMessage('foo', 'bar'),
                         'test id',
                     ),
                     ['failure-1' => ['a', 'b', 'c']],

--- a/tests/Benchmark/QueueBench.php
+++ b/tests/Benchmark/QueueBench.php
@@ -11,7 +11,7 @@ use Yiisoft\Injector\Injector;
 use Yiisoft\Queue\Cli\SimpleLoop;
 use Yiisoft\Queue\Message\IdEnvelope;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareDispatcher;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareFactory;
@@ -66,11 +66,11 @@ final class QueueBench
 
     public function providePush(): Generator
     {
-        yield 'simple' => ['message' => new SimpleMessage('foo', 'bar')];
+        yield 'simple' => ['message' => new GenericMessage('foo', 'bar')];
         yield 'with envelopes' => [
             'message' => new FailureEnvelope(
                 new IdEnvelope(
-                    new SimpleMessage('foo', 'bar'),
+                    new GenericMessage('foo', 'bar'),
                     'test id',
                 ),
                 ['failure-1' => ['a', 'b', 'c']],
@@ -86,12 +86,12 @@ final class QueueBench
 
     public function provideConsume(): Generator
     {
-        yield 'simple mapping' => ['message' => $this->serializer->serialize(new SimpleMessage('foo', 'bar'))];
+        yield 'simple mapping' => ['message' => $this->serializer->serialize(new GenericMessage('foo', 'bar'))];
         yield 'with envelopes mapping' => [
             'message' => $this->serializer->serialize(
                 new FailureEnvelope(
                     new IdEnvelope(
-                        new SimpleMessage('foo', 'bar'),
+                        new GenericMessage('foo', 'bar'),
                         'test id',
                     ),
                     ['failure-1' => ['a', 'b', 'c']],

--- a/tests/Integration/MessageConsumingTest.php
+++ b/tests/Integration/MessageConsumingTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Queue\Tests\Integration;
 use Psr\Container\ContainerInterface;
 use Psr\Log\NullLogger;
 use Yiisoft\Injector\Injector;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareDispatcher;
@@ -45,8 +45,8 @@ final class MessageConsumingTest extends TestCase
 
         $messages = [1, 'foo', 'bar-baz'];
         foreach ($messages as $message) {
-            $worker->process(new SimpleMessage('test', $message), $this->getQueue());
-            $worker->process(new SimpleMessage('test2', $message), $this->getQueue());
+            $worker->process(new GenericMessage('test', $message), $this->getQueue());
+            $worker->process(new GenericMessage('test2', $message), $this->getQueue());
         }
 
         $this->assertEquals($messages, $this->messagesProcessed);
@@ -72,7 +72,7 @@ final class MessageConsumingTest extends TestCase
 
         $messages = [1, 'foo', 'bar-baz'];
         foreach ($messages as $message) {
-            $worker->process(new SimpleMessage(TestHandler::class, $message), $this->getQueue());
+            $worker->process(new GenericMessage(TestHandler::class, $message), $this->getQueue());
         }
 
         $this->assertEquals($messages, $handler->messagesProcessed);

--- a/tests/Integration/MessageConsumingTest.php
+++ b/tests/Integration/MessageConsumingTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Queue\Tests\Integration;
 use Psr\Container\ContainerInterface;
 use Psr\Log\NullLogger;
 use Yiisoft\Injector\Injector;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareDispatcher;
@@ -45,8 +45,8 @@ final class MessageConsumingTest extends TestCase
 
         $messages = [1, 'foo', 'bar-baz'];
         foreach ($messages as $message) {
-            $worker->process(new Message('test', $message), $this->getQueue());
-            $worker->process(new Message('test2', $message), $this->getQueue());
+            $worker->process(new SimpleMessage('test', $message), $this->getQueue());
+            $worker->process(new SimpleMessage('test2', $message), $this->getQueue());
         }
 
         $this->assertEquals($messages, $this->messagesProcessed);
@@ -72,7 +72,7 @@ final class MessageConsumingTest extends TestCase
 
         $messages = [1, 'foo', 'bar-baz'];
         foreach ($messages as $message) {
-            $worker->process(new Message(TestHandler::class, $message), $this->getQueue());
+            $worker->process(new SimpleMessage(TestHandler::class, $message), $this->getQueue());
         }
 
         $this->assertEquals($messages, $handler->messagesProcessed);

--- a/tests/Integration/MiddlewareTest.php
+++ b/tests/Integration/MiddlewareTest.php
@@ -12,7 +12,7 @@ use Yiisoft\Injector\Injector;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Test\Support\Log\SimpleLogger;
 use Yiisoft\Queue\Cli\LoopInterface;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareDispatcher;
@@ -71,7 +71,7 @@ final class MiddlewareTest extends TestCase
             ->withMiddlewares(new TestMiddleware('channel 1'), new TestMiddleware('channel 2'))
             ->withMiddlewaresAdded(new TestMiddleware('channel 3'), new TestMiddleware('channel 4'));
 
-        $message = new SimpleMessage('test', ['initial']);
+        $message = new GenericMessage('test', ['initial']);
         $messagePushed = $queue->push($message);
 
         self::assertEquals($stack, $messagePushed->getData());
@@ -113,7 +113,7 @@ final class MiddlewareTest extends TestCase
             $callableFactory,
         );
 
-        $message = new SimpleMessage('test', ['initial']);
+        $message = new GenericMessage('test', ['initial']);
         $messageConsumed = $worker->process($message, $this->createMock(QueueInterface::class));
 
         self::assertEquals($stack, $messageConsumed->getData());
@@ -124,7 +124,7 @@ final class MiddlewareTest extends TestCase
         $exception = new InvalidArgumentException('test');
         $this->expectExceptionObject($exception);
 
-        $message = new SimpleMessage('simple', null, []);
+        $message = new GenericMessage('simple', null, []);
         $queueCallback = static fn(MessageInterface $message): MessageInterface => $message;
         $queue = $this->createMock(QueueInterface::class);
         $container = new SimpleContainer([SendAgainMiddleware::class => new SendAgainMiddleware('test-container', 1, $queue)]);

--- a/tests/Integration/MiddlewareTest.php
+++ b/tests/Integration/MiddlewareTest.php
@@ -124,7 +124,7 @@ final class MiddlewareTest extends TestCase
         $exception = new InvalidArgumentException('test');
         $this->expectExceptionObject($exception);
 
-        $message = new GenericMessage('simple', null, []);
+        $message = new GenericMessage('simple', null);
         $queueCallback = static fn(MessageInterface $message): MessageInterface => $message;
         $queue = $this->createMock(QueueInterface::class);
         $container = new SimpleContainer([SendAgainMiddleware::class => new SendAgainMiddleware('test-container', 1, $queue)]);

--- a/tests/Integration/MiddlewareTest.php
+++ b/tests/Integration/MiddlewareTest.php
@@ -12,7 +12,7 @@ use Yiisoft\Injector\Injector;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Test\Support\Log\SimpleLogger;
 use Yiisoft\Queue\Cli\LoopInterface;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareDispatcher;
@@ -71,7 +71,7 @@ final class MiddlewareTest extends TestCase
             ->withMiddlewares(new TestMiddleware('channel 1'), new TestMiddleware('channel 2'))
             ->withMiddlewaresAdded(new TestMiddleware('channel 3'), new TestMiddleware('channel 4'));
 
-        $message = new Message('test', ['initial']);
+        $message = new SimpleMessage('test', ['initial']);
         $messagePushed = $queue->push($message);
 
         self::assertEquals($stack, $messagePushed->getData());
@@ -113,7 +113,7 @@ final class MiddlewareTest extends TestCase
             $callableFactory,
         );
 
-        $message = new Message('test', ['initial']);
+        $message = new SimpleMessage('test', ['initial']);
         $messageConsumed = $worker->process($message, $this->createMock(QueueInterface::class));
 
         self::assertEquals($stack, $messageConsumed->getData());
@@ -124,7 +124,7 @@ final class MiddlewareTest extends TestCase
         $exception = new InvalidArgumentException('test');
         $this->expectExceptionObject($exception);
 
-        $message = new Message('simple', null, []);
+        $message = new SimpleMessage('simple', null, []);
         $queueCallback = static fn(MessageInterface $message): MessageInterface => $message;
         $queue = $this->createMock(QueueInterface::class);
         $container = new SimpleContainer([SendAgainMiddleware::class => new SendAgainMiddleware('test-container', 1, $queue)]);

--- a/tests/Integration/Support/TestMiddleware.php
+++ b/tests/Integration/Support/TestMiddleware.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Integration\Support;
 
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
 use Yiisoft\Queue\Middleware\Consume\ConsumeHandlerInterface;
@@ -21,7 +21,7 @@ final class TestMiddleware implements PushMiddlewareInterface, ConsumeMiddleware
         $stack = $message->getData();
         $stack[] = $this->stage;
 
-        return $handler->handlePush(new SimpleMessage($message->getType(), $stack));
+        return $handler->handlePush(new GenericMessage($message->getType(), $stack));
     }
 
     public function processConsume(ConsumeRequest $request, ConsumeHandlerInterface $handler): ConsumeRequest
@@ -29,7 +29,7 @@ final class TestMiddleware implements PushMiddlewareInterface, ConsumeMiddleware
         $message = $request->getMessage();
         $stack = $message->getData();
         $stack[] = $this->stage;
-        $messageNew = new SimpleMessage($message->getType(), $stack);
+        $messageNew = new GenericMessage($message->getType(), $stack);
 
         return $handler->handleConsume($request->withMessage($messageNew));
     }

--- a/tests/Integration/Support/TestMiddleware.php
+++ b/tests/Integration/Support/TestMiddleware.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Integration\Support;
 
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
 use Yiisoft\Queue\Middleware\Consume\ConsumeHandlerInterface;
@@ -21,7 +21,7 @@ final class TestMiddleware implements PushMiddlewareInterface, ConsumeMiddleware
         $stack = $message->getData();
         $stack[] = $this->stage;
 
-        return $handler->handlePush(new Message($message->getType(), $stack));
+        return $handler->handlePush(new SimpleMessage($message->getType(), $stack));
     }
 
     public function processConsume(ConsumeRequest $request, ConsumeHandlerInterface $handler): ConsumeRequest
@@ -29,7 +29,7 @@ final class TestMiddleware implements PushMiddlewareInterface, ConsumeMiddleware
         $message = $request->getMessage();
         $stack = $message->getData();
         $stack[] = $this->stage;
-        $messageNew = new Message($message->getType(), $stack);
+        $messageNew = new SimpleMessage($message->getType(), $stack);
 
         return $handler->handleConsume($request->withMessage($messageNew));
     }

--- a/tests/Unit/Debug/QueueCollectorTest.php
+++ b/tests/Unit/Debug/QueueCollectorTest.php
@@ -8,17 +8,17 @@ use Yiisoft\Queue\MessageStatus;
 use Yiisoft\Yii\Debug\Collector\CollectorInterface;
 use Yiisoft\Yii\Debug\Tests\Shared\AbstractCollectorTestCase;
 use Yiisoft\Queue\Debug\QueueCollector;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Stubs\StubQueue;
 
 final class QueueCollectorTest extends AbstractCollectorTestCase
 {
-    private SimpleMessage $pushMessage;
+    private GenericMessage $pushMessage;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->pushMessage = new SimpleMessage('task', ['id' => 500]);
+        $this->pushMessage = new GenericMessage('task', ['id' => 500]);
     }
 
     /**

--- a/tests/Unit/Debug/QueueCollectorTest.php
+++ b/tests/Unit/Debug/QueueCollectorTest.php
@@ -8,17 +8,17 @@ use Yiisoft\Queue\MessageStatus;
 use Yiisoft\Yii\Debug\Collector\CollectorInterface;
 use Yiisoft\Yii\Debug\Tests\Shared\AbstractCollectorTestCase;
 use Yiisoft\Queue\Debug\QueueCollector;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Stubs\StubQueue;
 
 final class QueueCollectorTest extends AbstractCollectorTestCase
 {
-    private Message $pushMessage;
+    private SimpleMessage $pushMessage;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->pushMessage = new Message('task', ['id' => 500]);
+        $this->pushMessage = new SimpleMessage('task', ['id' => 500]);
     }
 
     /**

--- a/tests/Unit/Debug/QueueWorkerInterfaceProxyTest.php
+++ b/tests/Unit/Debug/QueueWorkerInterfaceProxyTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Queue\Tests\Unit\Debug;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Debug\QueueCollector;
 use Yiisoft\Queue\Debug\QueueWorkerInterfaceProxy;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Stubs\StubQueue;
 use Yiisoft\Queue\Stubs\StubWorker;
 
@@ -15,7 +15,7 @@ final class QueueWorkerInterfaceProxyTest extends TestCase
 {
     public function testProcessDelegatesToWorker(): void
     {
-        $message = new SimpleMessage('handler', 'data');
+        $message = new GenericMessage('handler', 'data');
         $collector = new QueueCollector();
         $collector->startup();
         $proxy = new QueueWorkerInterfaceProxy(new StubWorker(), $collector);

--- a/tests/Unit/Debug/QueueWorkerInterfaceProxyTest.php
+++ b/tests/Unit/Debug/QueueWorkerInterfaceProxyTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Queue\Tests\Unit\Debug;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Debug\QueueCollector;
 use Yiisoft\Queue\Debug\QueueWorkerInterfaceProxy;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Stubs\StubQueue;
 use Yiisoft\Queue\Stubs\StubWorker;
 
@@ -15,7 +15,7 @@ final class QueueWorkerInterfaceProxyTest extends TestCase
 {
     public function testProcessDelegatesToWorker(): void
     {
-        $message = new Message('handler', 'data');
+        $message = new SimpleMessage('handler', 'data');
         $collector = new QueueCollector();
         $collector->startup();
         $proxy = new QueueWorkerInterfaceProxy(new StubWorker(), $collector);

--- a/tests/Unit/EnvelopeTest.php
+++ b/tests/Unit/EnvelopeTest.php
@@ -6,13 +6,13 @@ namespace Yiisoft\Queue\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Message\IdEnvelope;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 
 final class EnvelopeTest extends TestCase
 {
     public function testEnvelopeStack(): void
     {
-        $message = new SimpleMessage('handler', 'test');
+        $message = new GenericMessage('handler', 'test');
         $message = new IdEnvelope($message, 'test-id');
 
         $this->assertEquals('test', $message->getMessage()->getData());
@@ -21,7 +21,7 @@ final class EnvelopeTest extends TestCase
 
     public function testEnvelopeDuplicates(): void
     {
-        $message = new SimpleMessage('handler', 'test');
+        $message = new GenericMessage('handler', 'test');
         $message = new IdEnvelope($message, 'test-id-1');
         $message = new IdEnvelope($message, 'test-id-2');
         $message = new IdEnvelope($message, 'test-id-3');

--- a/tests/Unit/EnvelopeTest.php
+++ b/tests/Unit/EnvelopeTest.php
@@ -6,13 +6,13 @@ namespace Yiisoft\Queue\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Message\IdEnvelope;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 
 final class EnvelopeTest extends TestCase
 {
     public function testEnvelopeStack(): void
     {
-        $message = new Message('handler', 'test');
+        $message = new SimpleMessage('handler', 'test');
         $message = new IdEnvelope($message, 'test-id');
 
         $this->assertEquals('test', $message->getMessage()->getData());
@@ -21,7 +21,7 @@ final class EnvelopeTest extends TestCase
 
     public function testEnvelopeDuplicates(): void
     {
-        $message = new Message('handler', 'test');
+        $message = new SimpleMessage('handler', 'test');
         $message = new IdEnvelope($message, 'test-id-1');
         $message = new IdEnvelope($message, 'test-id-2');
         $message = new IdEnvelope($message, 'test-id-3');

--- a/tests/Unit/Message/DelayEnvelopeTest.php
+++ b/tests/Unit/Message/DelayEnvelopeTest.php
@@ -6,13 +6,13 @@ namespace Yiisoft\Queue\Tests\Unit\Message;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Message\DelayEnvelope;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 
 final class DelayEnvelopeTest extends TestCase
 {
     public function testDelayEnvelope(): void
     {
-        $message = new Message('test', ['data' => 'value']);
+        $message = new SimpleMessage('test', ['data' => 'value']);
         $delayEnvelope = new DelayEnvelope($message, 300.5);
 
         self::assertSame($message, $delayEnvelope->getMessage());
@@ -27,7 +27,7 @@ final class DelayEnvelopeTest extends TestCase
 
     public function testFromMessage(): void
     {
-        $message = new Message('test', ['data' => 'value'], [DelayEnvelope::META_DELAY_SECONDS => 150]);
+        $message = (new SimpleMessage('test', ['data' => 'value']))->withMetadata([DelayEnvelope::META_DELAY_SECONDS => 150]);
         $delayEnvelope = DelayEnvelope::fromMessage($message);
 
         self::assertSame(150.0, $delayEnvelope->getDelaySeconds());
@@ -37,7 +37,7 @@ final class DelayEnvelopeTest extends TestCase
 
     public function testFromMessageWithoutDelay(): void
     {
-        $message = new Message('test', ['data' => 'value']);
+        $message = new SimpleMessage('test', ['data' => 'value']);
         $delayEnvelope = DelayEnvelope::fromMessage($message);
 
         self::assertSame(0.0, $delayEnvelope->getDelaySeconds());

--- a/tests/Unit/Message/DelayEnvelopeTest.php
+++ b/tests/Unit/Message/DelayEnvelopeTest.php
@@ -6,13 +6,13 @@ namespace Yiisoft\Queue\Tests\Unit\Message;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Message\DelayEnvelope;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 
 final class DelayEnvelopeTest extends TestCase
 {
     public function testDelayEnvelope(): void
     {
-        $message = new SimpleMessage('test', ['data' => 'value']);
+        $message = new GenericMessage('test', ['data' => 'value']);
         $delayEnvelope = new DelayEnvelope($message, 300.5);
 
         self::assertSame($message, $delayEnvelope->getMessage());
@@ -27,7 +27,7 @@ final class DelayEnvelopeTest extends TestCase
 
     public function testFromMessage(): void
     {
-        $message = (new SimpleMessage('test', ['data' => 'value']))->withMetadata([DelayEnvelope::META_DELAY_SECONDS => 150]);
+        $message = (new GenericMessage('test', ['data' => 'value']))->withMetadata([DelayEnvelope::META_DELAY_SECONDS => 150]);
         $delayEnvelope = DelayEnvelope::fromMessage($message);
 
         self::assertSame(150.0, $delayEnvelope->getDelaySeconds());
@@ -37,7 +37,7 @@ final class DelayEnvelopeTest extends TestCase
 
     public function testFromMessageWithoutDelay(): void
     {
-        $message = new SimpleMessage('test', ['data' => 'value']);
+        $message = new GenericMessage('test', ['data' => 'value']);
         $delayEnvelope = DelayEnvelope::fromMessage($message);
 
         self::assertSame(0.0, $delayEnvelope->getDelaySeconds());

--- a/tests/Unit/Message/DelayEnvelopeTest.php
+++ b/tests/Unit/Message/DelayEnvelopeTest.php
@@ -27,8 +27,10 @@ final class DelayEnvelopeTest extends TestCase
 
     public function testFromMessage(): void
     {
-        $message = (new GenericMessage('test', ['data' => 'value']))->withMetadata([DelayEnvelope::META_DELAY_SECONDS => 150]);
-        $delayEnvelope = DelayEnvelope::fromMessage($message);
+        $delayEnvelope = DelayEnvelope::fromMessage(
+            (new GenericMessage('test', ['data' => 'value']))
+                ->withMetadata([DelayEnvelope::META_DELAY_SECONDS => 150])
+        );
 
         self::assertSame(150.0, $delayEnvelope->getDelaySeconds());
         self::assertSame('test', $delayEnvelope->getType());

--- a/tests/Unit/Message/EnvelopeTest.php
+++ b/tests/Unit/Message/EnvelopeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Message;
 
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Tests\App\DummyEnvelope;
 
@@ -11,16 +12,10 @@ final class EnvelopeTest extends TestCase
 {
     public function testFromData(): void
     {
-        $type = 'test-handler';
-        $data = ['key' => 'value'];
-        $metadata = ['meta' => 'data'];
-
-        $envelope = DummyEnvelope::fromData($type, $data, $metadata);
-
-        $this->assertInstanceOf(DummyEnvelope::class, $envelope);
-        $this->assertSame($type, $envelope->getType());
-        $this->assertSame($data, $envelope->getData());
-        $this->assertArrayHasKey('meta', $envelope->getMetadata());
-        $this->assertSame('data', $envelope->getMetadata()['meta']);
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'Envelopes cannot be created via "fromData()". Wrap an existing "MessageInterface" instance instead.'
+        );
+        DummyEnvelope::fromData('test', []);
     }
 }

--- a/tests/Unit/Message/EnvelopeTest.php
+++ b/tests/Unit/Message/EnvelopeTest.php
@@ -14,7 +14,7 @@ final class EnvelopeTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage(
-            'Envelopes cannot be created via "fromData()". Wrap an existing "MessageInterface" instance instead.'
+            'Envelopes cannot be created via "fromData()". Wrap an existing "MessageInterface" instance instead.',
         );
         DummyEnvelope::fromData('test', []);
     }

--- a/tests/Unit/Message/IdEnvelopeTest.php
+++ b/tests/Unit/Message/IdEnvelopeTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Queue\Tests\Unit\Message;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Message\IdEnvelope;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 
 final class IdEnvelopeTest extends TestCase
@@ -88,6 +88,6 @@ final class IdEnvelopeTest extends TestCase
 
     private function createMessage(array $metadata = []): MessageInterface
     {
-        return (new SimpleMessage('test-handler', ['test-data']))->withMetadata($metadata);
+        return (new GenericMessage('test-handler', ['test-data']))->withMetadata($metadata);
     }
 }

--- a/tests/Unit/Message/IdEnvelopeTest.php
+++ b/tests/Unit/Message/IdEnvelopeTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Queue\Tests\Unit\Message;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Message\IdEnvelope;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 
 final class IdEnvelopeTest extends TestCase
@@ -86,24 +86,8 @@ final class IdEnvelopeTest extends TestCase
         $this->assertSame($id, $metadata[IdEnvelope::MESSAGE_ID_KEY]);
     }
 
-    public function testFromData(): void
-    {
-        $type = 'test-handler';
-        $data = ['key' => 'value'];
-        $metadata = ['meta' => 'data', IdEnvelope::MESSAGE_ID_KEY => 'test-id'];
-
-        $envelope = IdEnvelope::fromData($type, $data, $metadata);
-
-        $this->assertInstanceOf(IdEnvelope::class, $envelope);
-        $this->assertSame($type, $envelope->getType());
-        $this->assertSame($data, $envelope->getData());
-        $this->assertArrayHasKey('meta', $envelope->getMetadata());
-        $this->assertSame('data', $envelope->getMetadata()['meta']);
-        $this->assertSame('test-id', $envelope->getId());
-    }
-
     private function createMessage(array $metadata = []): MessageInterface
     {
-        return new Message('test-handler', ['test-data'], $metadata);
+        return (new SimpleMessage('test-handler', ['test-data']))->withMetadata($metadata);
     }
 }

--- a/tests/Unit/Message/JsonMessageSerializerTest.php
+++ b/tests/Unit/Message/JsonMessageSerializerTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Message\IdEnvelope;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Tests\Unit\Support\TestMessage;
 
 use function sprintf;
@@ -55,7 +55,7 @@ final class JsonMessageSerializerTest extends TestCase
         ];
 
         $message = $serializer->unserialize(json_encode($payload, JSON_THROW_ON_ERROR));
-        $this->assertInstanceOf(Message::class, $message);
+        $this->assertInstanceOf(SimpleMessage::class, $message);
     }
 
     public function testDefaultMessageClassFallbackClassNotSet(): void
@@ -67,7 +67,7 @@ final class JsonMessageSerializerTest extends TestCase
             'meta' => [],
         ];
         $message = $serializer->unserialize(json_encode($payload, JSON_THROW_ON_ERROR));
-        $this->assertInstanceOf(Message::class, $message);
+        $this->assertInstanceOf(SimpleMessage::class, $message);
     }
 
     #[DataProvider('dataUnsupportedPayloadFormat')]
@@ -130,21 +130,21 @@ final class JsonMessageSerializerTest extends TestCase
 
     public function testSerialize(): void
     {
-        $message = new Message('handler', 'test');
+        $message = new SimpleMessage('handler', 'test');
 
         $serializer = $this->createSerializer();
 
         $json = $serializer->serialize($message);
 
         $this->assertEquals(
-            '{"type":"handler","data":"test","meta":{"message-class":"Yiisoft\\\\Queue\\\\Message\\\\Message"}}',
+            '{"type":"handler","data":"test","meta":{"message-class":"Yiisoft\\\\Queue\\\\Message\\\\SimpleMessage"}}',
             $json,
         );
     }
 
     public function testSerializeEnvelopeStack(): void
     {
-        $message = new Message('handler', 'test');
+        $message = new SimpleMessage('handler', 'test');
         $message = new IdEnvelope($message, 'test-id');
 
         $serializer = $this->createSerializer();
@@ -155,17 +155,17 @@ final class JsonMessageSerializerTest extends TestCase
             sprintf(
                 '{"type":"handler","data":"test","meta":{"%s":"test-id","message-class":"%s"}}',
                 IdEnvelope::MESSAGE_ID_KEY,
-                str_replace('\\', '\\\\', Message::class),
+                str_replace('\\', '\\\\', SimpleMessage::class),
             ),
             $json,
         );
 
         $message = $serializer->unserialize($json);
 
-        $this->assertInstanceOf(Message::class, $message);
+        $this->assertInstanceOf(SimpleMessage::class, $message);
         $this->assertEquals([
             IdEnvelope::MESSAGE_ID_KEY => 'test-id',
-            'message-class' => Message::class,
+            'message-class' => SimpleMessage::class,
         ], $message->getMetadata());
     }
 

--- a/tests/Unit/Message/JsonMessageSerializerTest.php
+++ b/tests/Unit/Message/JsonMessageSerializerTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Message\IdEnvelope;
 use Yiisoft\Queue\Message\JsonMessageSerializer;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Tests\Unit\Support\TestMessage;
 
 use function sprintf;
@@ -55,7 +55,7 @@ final class JsonMessageSerializerTest extends TestCase
         ];
 
         $message = $serializer->unserialize(json_encode($payload, JSON_THROW_ON_ERROR));
-        $this->assertInstanceOf(SimpleMessage::class, $message);
+        $this->assertInstanceOf(GenericMessage::class, $message);
     }
 
     public function testDefaultMessageClassFallbackClassNotSet(): void
@@ -67,7 +67,7 @@ final class JsonMessageSerializerTest extends TestCase
             'meta' => [],
         ];
         $message = $serializer->unserialize(json_encode($payload, JSON_THROW_ON_ERROR));
-        $this->assertInstanceOf(SimpleMessage::class, $message);
+        $this->assertInstanceOf(GenericMessage::class, $message);
     }
 
     #[DataProvider('dataUnsupportedPayloadFormat')]
@@ -130,7 +130,7 @@ final class JsonMessageSerializerTest extends TestCase
 
     public function testSerialize(): void
     {
-        $message = new SimpleMessage('handler', 'test');
+        $message = new GenericMessage('handler', 'test');
 
         $serializer = $this->createSerializer();
 
@@ -144,7 +144,7 @@ final class JsonMessageSerializerTest extends TestCase
 
     public function testSerializeEnvelopeStack(): void
     {
-        $message = new SimpleMessage('handler', 'test');
+        $message = new GenericMessage('handler', 'test');
         $message = new IdEnvelope($message, 'test-id');
 
         $serializer = $this->createSerializer();
@@ -155,17 +155,17 @@ final class JsonMessageSerializerTest extends TestCase
             sprintf(
                 '{"type":"handler","data":"test","meta":{"%s":"test-id","message-class":"%s"}}',
                 IdEnvelope::MESSAGE_ID_KEY,
-                str_replace('\\', '\\\\', SimpleMessage::class),
+                str_replace('\\', '\\\\', GenericMessage::class),
             ),
             $json,
         );
 
         $message = $serializer->unserialize($json);
 
-        $this->assertInstanceOf(SimpleMessage::class, $message);
+        $this->assertInstanceOf(GenericMessage::class, $message);
         $this->assertEquals([
             IdEnvelope::MESSAGE_ID_KEY => 'test-id',
-            'message-class' => SimpleMessage::class,
+            'message-class' => GenericMessage::class,
         ], $message->getMetadata());
     }
 

--- a/tests/Unit/Message/JsonMessageSerializerTest.php
+++ b/tests/Unit/Message/JsonMessageSerializerTest.php
@@ -137,7 +137,7 @@ final class JsonMessageSerializerTest extends TestCase
         $json = $serializer->serialize($message);
 
         $this->assertEquals(
-            '{"type":"handler","data":"test","meta":{"message-class":"Yiisoft\\\\Queue\\\\Message\\\\SimpleMessage"}}',
+            '{"type":"handler","data":"test","meta":{"message-class":"Yiisoft\\\\Queue\\\\Message\\\\GenericMessage"}}',
             $json,
         );
     }

--- a/tests/Unit/Middleware/Consume/ConsumeRequestTest.php
+++ b/tests/Unit/Middleware/Consume/ConsumeRequestTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Consume;
 
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
 use Yiisoft\Queue\QueueInterface;
 use Yiisoft\Queue\Tests\TestCase;
@@ -13,7 +13,7 @@ final class ConsumeRequestTest extends TestCase
 {
     public function testImmutable(): void
     {
-        $message = new SimpleMessage('test', 'test');
+        $message = new GenericMessage('test', 'test');
         $queue = $this->createMock(QueueInterface::class);
         $consumeRequest = new ConsumeRequest($message, $queue);
 

--- a/tests/Unit/Middleware/Consume/ConsumeRequestTest.php
+++ b/tests/Unit/Middleware/Consume/ConsumeRequestTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Consume;
 
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
 use Yiisoft\Queue\QueueInterface;
 use Yiisoft\Queue\Tests\TestCase;
@@ -13,7 +13,7 @@ final class ConsumeRequestTest extends TestCase
 {
     public function testImmutable(): void
     {
-        $message = new Message('test', 'test');
+        $message = new SimpleMessage('test', 'test');
         $queue = $this->createMock(QueueInterface::class);
         $consumeRequest = new ConsumeRequest($message, $queue);
 

--- a/tests/Unit/Middleware/Consume/MiddlewareDispatcherTest.php
+++ b/tests/Unit/Middleware/Consume/MiddlewareDispatcherTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Queue\Adapter\AdapterInterface;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareDispatcher;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
@@ -30,7 +30,7 @@ final class MiddlewareDispatcherTest extends TestCase
         $dispatcher = $this->createDispatcher()->withMiddlewares(
             [
                 static function (ConsumeRequest $request) use ($queue): ConsumeRequest {
-                    return $request->withMessage(new SimpleMessage('test', 'New closure test data'))->withQueue($queue);
+                    return $request->withMessage(new GenericMessage('test', 'New closure test data'))->withQueue($queue);
                 },
             ],
         );
@@ -70,12 +70,12 @@ final class MiddlewareDispatcherTest extends TestCase
         $request = $this->getConsumeRequest();
 
         $middleware1 = static function (ConsumeRequest $request, ConsumeHandlerInterface $handler): ConsumeRequest {
-            $request = $request->withMessage(new SimpleMessage($request->getMessage()->getType(), 'new test data'));
+            $request = $request->withMessage(new GenericMessage($request->getMessage()->getType(), 'new test data'));
 
             return $handler->handleConsume($request);
         };
         $middleware2 = static function (ConsumeRequest $request, ConsumeHandlerInterface $handler): ConsumeRequest {
-            $request = $request->withMessage(new SimpleMessage('new handler', $request->getMessage()->getData()));
+            $request = $request->withMessage(new GenericMessage('new handler', $request->getMessage()->getData()));
 
             return $handler->handleConsume($request);
         };
@@ -92,10 +92,10 @@ final class MiddlewareDispatcherTest extends TestCase
         $request = $this->getConsumeRequest();
 
         $middleware1 = static function (ConsumeRequest $request, ConsumeHandlerInterface $handler): ConsumeRequest {
-            return $request->withMessage(new SimpleMessage($request->getMessage()->getType(), 'first'));
+            return $request->withMessage(new GenericMessage($request->getMessage()->getType(), 'first'));
         };
         $middleware2 = static function (ConsumeRequest $request, ConsumeHandlerInterface $handler): ConsumeRequest {
-            return $request->withMessage(new SimpleMessage($request->getMessage()->getType(), 'second'));
+            return $request->withMessage(new GenericMessage($request->getMessage()->getType(), 'second'));
         };
 
         $dispatcher = $this->createDispatcher()->withMiddlewares([$middleware1, $middleware2]);
@@ -177,7 +177,7 @@ final class MiddlewareDispatcherTest extends TestCase
     private function getConsumeRequest(): ConsumeRequest
     {
         return new ConsumeRequest(
-            new SimpleMessage('handler', 'data'),
+            new GenericMessage('handler', 'data'),
             $this->createMock(QueueInterface::class),
         );
     }

--- a/tests/Unit/Middleware/Consume/MiddlewareDispatcherTest.php
+++ b/tests/Unit/Middleware/Consume/MiddlewareDispatcherTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Queue\Adapter\AdapterInterface;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareDispatcher;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
@@ -30,7 +30,7 @@ final class MiddlewareDispatcherTest extends TestCase
         $dispatcher = $this->createDispatcher()->withMiddlewares(
             [
                 static function (ConsumeRequest $request) use ($queue): ConsumeRequest {
-                    return $request->withMessage(new Message('test', 'New closure test data'))->withQueue($queue);
+                    return $request->withMessage(new SimpleMessage('test', 'New closure test data'))->withQueue($queue);
                 },
             ],
         );
@@ -70,12 +70,12 @@ final class MiddlewareDispatcherTest extends TestCase
         $request = $this->getConsumeRequest();
 
         $middleware1 = static function (ConsumeRequest $request, ConsumeHandlerInterface $handler): ConsumeRequest {
-            $request = $request->withMessage(new Message($request->getMessage()->getType(), 'new test data'));
+            $request = $request->withMessage(new SimpleMessage($request->getMessage()->getType(), 'new test data'));
 
             return $handler->handleConsume($request);
         };
         $middleware2 = static function (ConsumeRequest $request, ConsumeHandlerInterface $handler): ConsumeRequest {
-            $request = $request->withMessage(new Message('new handler', $request->getMessage()->getData()));
+            $request = $request->withMessage(new SimpleMessage('new handler', $request->getMessage()->getData()));
 
             return $handler->handleConsume($request);
         };
@@ -92,10 +92,10 @@ final class MiddlewareDispatcherTest extends TestCase
         $request = $this->getConsumeRequest();
 
         $middleware1 = static function (ConsumeRequest $request, ConsumeHandlerInterface $handler): ConsumeRequest {
-            return $request->withMessage(new Message($request->getMessage()->getType(), 'first'));
+            return $request->withMessage(new SimpleMessage($request->getMessage()->getType(), 'first'));
         };
         $middleware2 = static function (ConsumeRequest $request, ConsumeHandlerInterface $handler): ConsumeRequest {
-            return $request->withMessage(new Message($request->getMessage()->getType(), 'second'));
+            return $request->withMessage(new SimpleMessage($request->getMessage()->getType(), 'second'));
         };
 
         $dispatcher = $this->createDispatcher()->withMiddlewares([$middleware1, $middleware2]);
@@ -177,7 +177,7 @@ final class MiddlewareDispatcherTest extends TestCase
     private function getConsumeRequest(): ConsumeRequest
     {
         return new ConsumeRequest(
-            new Message('handler', 'data'),
+            new SimpleMessage('handler', 'data'),
             $this->createMock(QueueInterface::class),
         );
     }

--- a/tests/Unit/Middleware/Consume/MiddlewareFactoryTest.php
+++ b/tests/Unit/Middleware/Consume/MiddlewareFactoryTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Queue\Adapter\AdapterInterface;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
 use Yiisoft\Queue\Middleware\Consume\ConsumeHandlerInterface;
@@ -61,7 +61,7 @@ final class MiddlewareFactoryTest extends TestCase
         $container = $this->getContainer([TestCallableMiddleware::class => new TestCallableMiddleware()]);
         $middleware = $this->getMiddlewareFactory($container)->createConsumeMiddleware(
             fn(): ConsumeRequest => new ConsumeRequest(
-                new SimpleMessage('test', 'test data'),
+                new GenericMessage('test', 'test data'),
                 $this->createMock(QueueInterface::class),
             ),
         );
@@ -222,7 +222,7 @@ final class MiddlewareFactoryTest extends TestCase
     private function getConsumeRequest(): ConsumeRequest
     {
         return new ConsumeRequest(
-            new SimpleMessage('handler', 'data'),
+            new GenericMessage('handler', 'data'),
             $this->createMock(QueueInterface::class),
         );
     }

--- a/tests/Unit/Middleware/Consume/MiddlewareFactoryTest.php
+++ b/tests/Unit/Middleware/Consume/MiddlewareFactoryTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Queue\Adapter\AdapterInterface;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
 use Yiisoft\Queue\Middleware\Consume\ConsumeHandlerInterface;
@@ -61,7 +61,7 @@ final class MiddlewareFactoryTest extends TestCase
         $container = $this->getContainer([TestCallableMiddleware::class => new TestCallableMiddleware()]);
         $middleware = $this->getMiddlewareFactory($container)->createConsumeMiddleware(
             fn(): ConsumeRequest => new ConsumeRequest(
-                new Message('test', 'test data'),
+                new SimpleMessage('test', 'test data'),
                 $this->createMock(QueueInterface::class),
             ),
         );
@@ -222,7 +222,7 @@ final class MiddlewareFactoryTest extends TestCase
     private function getConsumeRequest(): ConsumeRequest
     {
         return new ConsumeRequest(
-            new Message('handler', 'data'),
+            new SimpleMessage('handler', 'data'),
             $this->createMock(QueueInterface::class),
         );
     }

--- a/tests/Unit/Middleware/Consume/Support/CallableObjectMiddleware.php
+++ b/tests/Unit/Middleware/Consume/Support/CallableObjectMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Consume\Support;
 
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
 
 final class CallableObjectMiddleware
 {
     public function __invoke(ConsumeRequest $request): ConsumeRequest
     {
-        return $request->withMessage(new Message('test', 'Callable object data'));
+        return $request->withMessage(new SimpleMessage('test', 'Callable object data'));
     }
 }

--- a/tests/Unit/Middleware/Consume/Support/CallableObjectMiddleware.php
+++ b/tests/Unit/Middleware/Consume/Support/CallableObjectMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Consume\Support;
 
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
 
 final class CallableObjectMiddleware
 {
     public function __invoke(ConsumeRequest $request): ConsumeRequest
     {
-        return $request->withMessage(new SimpleMessage('test', 'Callable object data'));
+        return $request->withMessage(new GenericMessage('test', 'Callable object data'));
     }
 }

--- a/tests/Unit/Middleware/Consume/Support/StringCallableMiddleware.php
+++ b/tests/Unit/Middleware/Consume/Support/StringCallableMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Consume\Support;
 
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
 
 final class StringCallableMiddleware
 {
     public static function handle(ConsumeRequest $request): ConsumeRequest
     {
-        return $request->withMessage(new SimpleMessage('test', 'String callable data'));
+        return $request->withMessage(new GenericMessage('test', 'String callable data'));
     }
 }

--- a/tests/Unit/Middleware/Consume/Support/StringCallableMiddleware.php
+++ b/tests/Unit/Middleware/Consume/Support/StringCallableMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Consume\Support;
 
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
 
 final class StringCallableMiddleware
 {
     public static function handle(ConsumeRequest $request): ConsumeRequest
     {
-        return $request->withMessage(new Message('test', 'String callable data'));
+        return $request->withMessage(new SimpleMessage('test', 'String callable data'));
     }
 }

--- a/tests/Unit/Middleware/Consume/Support/TestCallableMiddleware.php
+++ b/tests/Unit/Middleware/Consume/Support/TestCallableMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Consume\Support;
 
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
 
 final class TestCallableMiddleware
 {
     public function index(ConsumeRequest $request): ConsumeRequest
     {
-        return $request->withMessage(new Message('test', 'New test data'));
+        return $request->withMessage(new SimpleMessage('test', 'New test data'));
     }
 }

--- a/tests/Unit/Middleware/Consume/Support/TestCallableMiddleware.php
+++ b/tests/Unit/Middleware/Consume/Support/TestCallableMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Consume\Support;
 
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
 
 final class TestCallableMiddleware
 {
     public function index(ConsumeRequest $request): ConsumeRequest
     {
-        return $request->withMessage(new SimpleMessage('test', 'New test data'));
+        return $request->withMessage(new GenericMessage('test', 'New test data'));
     }
 }

--- a/tests/Unit/Middleware/Consume/Support/TestMiddleware.php
+++ b/tests/Unit/Middleware/Consume/Support/TestMiddleware.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Consume\Support;
 
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\Consume\ConsumeHandlerInterface;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareInterface;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
@@ -15,6 +15,6 @@ final class TestMiddleware implements ConsumeMiddlewareInterface
 
     public function processConsume(ConsumeRequest $request, ConsumeHandlerInterface $handler): ConsumeRequest
     {
-        return $request->withMessage(new SimpleMessage('test', $this->message));
+        return $request->withMessage(new GenericMessage('test', $this->message));
     }
 }

--- a/tests/Unit/Middleware/Consume/Support/TestMiddleware.php
+++ b/tests/Unit/Middleware/Consume/Support/TestMiddleware.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Consume\Support;
 
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\Consume\ConsumeHandlerInterface;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareInterface;
 use Yiisoft\Queue\Middleware\Consume\ConsumeRequest;
@@ -15,6 +15,6 @@ final class TestMiddleware implements ConsumeMiddlewareInterface
 
     public function processConsume(ConsumeRequest $request, ConsumeHandlerInterface $handler): ConsumeRequest
     {
-        return $request->withMessage(new Message('test', $this->message));
+        return $request->withMessage(new SimpleMessage('test', $this->message));
     }
 }

--- a/tests/Unit/Middleware/FailureHandling/FailureEnvelopeTest.php
+++ b/tests/Unit/Middleware/FailureHandling/FailureEnvelopeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Queue\Tests\Unit\Middleware\FailureHandling;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureEnvelope;
 
@@ -57,27 +57,8 @@ final class FailureEnvelopeTest extends TestCase
         $this->assertSame('Last error', $mergedMetadata['lastError']);
     }
 
-    public function testFromData(): void
-    {
-        $type = 'test-handler';
-        $data = ['key' => 'value'];
-        $metadata = [
-            'meta' => 'data',
-            FailureEnvelope::FAILURE_META_KEY => ['attempt' => 1],
-        ];
-
-        $envelope = FailureEnvelope::fromData($type, $data, $metadata);
-
-        $this->assertInstanceOf(FailureEnvelope::class, $envelope);
-        $this->assertSame($type, $envelope->getType());
-        $this->assertSame($data, $envelope->getData());
-        $this->assertArrayHasKey('meta', $envelope->getMetadata());
-        $this->assertSame('data', $envelope->getMetadata()['meta']);
-        $this->assertSame(['attempt' => 1], $envelope->getMetadata()[FailureEnvelope::FAILURE_META_KEY]);
-    }
-
     private function createMessage(array $metadata = []): MessageInterface
     {
-        return new Message('test-handler', ['test-data'], $metadata);
+        return (new SimpleMessage('test-handler', ['test-data']))->withMetadata($metadata);
     }
 }

--- a/tests/Unit/Middleware/FailureHandling/FailureEnvelopeTest.php
+++ b/tests/Unit/Middleware/FailureHandling/FailureEnvelopeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Queue\Tests\Unit\Middleware\FailureHandling;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureEnvelope;
 
@@ -59,6 +59,6 @@ final class FailureEnvelopeTest extends TestCase
 
     private function createMessage(array $metadata = []): MessageInterface
     {
-        return (new SimpleMessage('test-handler', ['test-data']))->withMetadata($metadata);
+        return (new GenericMessage('test-handler', ['test-data']))->withMetadata($metadata);
     }
 }

--- a/tests/Unit/Middleware/FailureHandling/FailureHandlingRequestTest.php
+++ b/tests/Unit/Middleware/FailureHandling/FailureHandlingRequestTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Queue\Tests\Unit\Middleware\FailureHandling;
 
 use Exception;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 use Yiisoft\Queue\QueueInterface;
 use Yiisoft\Queue\Tests\TestCase;
@@ -16,13 +16,13 @@ final class FailureHandlingRequestTest extends TestCase
     {
         $queue = $this->createMock(QueueInterface::class);
         $request1 = new FailureHandlingRequest(
-            new Message('test', null),
+            new SimpleMessage('test', null),
             new Exception('exception 1'),
             $queue,
         );
         $request2 = $request1->withQueue($queue);
         $request3 = $request1->withException(new Exception('exception 2'));
-        $request4 = $request1->withMessage(new Message('test2', null));
+        $request4 = $request1->withMessage(new SimpleMessage('test2', null));
 
         $this->assertNotSame($request1, $request2);
 

--- a/tests/Unit/Middleware/FailureHandling/FailureHandlingRequestTest.php
+++ b/tests/Unit/Middleware/FailureHandling/FailureHandlingRequestTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Queue\Tests\Unit\Middleware\FailureHandling;
 
 use Exception;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 use Yiisoft\Queue\QueueInterface;
 use Yiisoft\Queue\Tests\TestCase;
@@ -16,13 +16,13 @@ final class FailureHandlingRequestTest extends TestCase
     {
         $queue = $this->createMock(QueueInterface::class);
         $request1 = new FailureHandlingRequest(
-            new SimpleMessage('test', null),
+            new GenericMessage('test', null),
             new Exception('exception 1'),
             $queue,
         );
         $request2 = $request1->withQueue($queue);
         $request3 = $request1->withException(new Exception('exception 2'));
-        $request4 = $request1->withMessage(new SimpleMessage('test2', null));
+        $request4 = $request1->withMessage(new GenericMessage('test2', null));
 
         $this->assertNotSame($request1, $request2);
 

--- a/tests/Unit/Middleware/FailureHandling/Implementation/ExponentialDelayMiddlewareTest.php
+++ b/tests/Unit/Middleware/FailureHandling/Implementation/ExponentialDelayMiddlewareTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Queue\Tests\Unit\Middleware\FailureHandling\Implementation;
 use Exception;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureEnvelope;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 use Yiisoft\Queue\Middleware\FailureHandling\Implementation\ExponentialDelayMiddleware;
@@ -131,7 +131,7 @@ final class ExponentialDelayMiddlewareTest extends TestCase
 
     public function testPipelineSuccess(): void
     {
-        $message = new SimpleMessage('test', null);
+        $message = new GenericMessage('test', null);
         $queue = $this->createMock(QueueInterface::class);
         $queue->method('push')->willReturnArgument(0);
         $middleware = new ExponentialDelayMiddleware(
@@ -162,7 +162,7 @@ final class ExponentialDelayMiddlewareTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('test');
 
-        $message = (new SimpleMessage(
+        $message = (new GenericMessage(
             'test',
             null,
         ))->withMetadata([FailureEnvelope::FAILURE_META_KEY => [ExponentialDelayMiddleware::META_KEY_ATTEMPTS . '-test' => 2]]);

--- a/tests/Unit/Middleware/FailureHandling/Implementation/ExponentialDelayMiddlewareTest.php
+++ b/tests/Unit/Middleware/FailureHandling/Implementation/ExponentialDelayMiddlewareTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Queue\Tests\Unit\Middleware\FailureHandling\Implementation;
 use Exception;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureEnvelope;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 use Yiisoft\Queue\Middleware\FailureHandling\Implementation\ExponentialDelayMiddleware;
@@ -131,7 +131,7 @@ final class ExponentialDelayMiddlewareTest extends TestCase
 
     public function testPipelineSuccess(): void
     {
-        $message = new Message('test', null);
+        $message = new SimpleMessage('test', null);
         $queue = $this->createMock(QueueInterface::class);
         $queue->method('push')->willReturnArgument(0);
         $middleware = new ExponentialDelayMiddleware(
@@ -162,11 +162,10 @@ final class ExponentialDelayMiddlewareTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('test');
 
-        $message = new Message(
+        $message = (new SimpleMessage(
             'test',
             null,
-            [FailureEnvelope::FAILURE_META_KEY => [ExponentialDelayMiddleware::META_KEY_ATTEMPTS . '-test' => 2]],
-        );
+        ))->withMetadata([FailureEnvelope::FAILURE_META_KEY => [ExponentialDelayMiddleware::META_KEY_ATTEMPTS . '-test' => 2]]);
         $queue = $this->createMock(QueueInterface::class);
         $middleware = new ExponentialDelayMiddleware(
             'test',

--- a/tests/Unit/Middleware/FailureHandling/Implementation/SendAgainMiddlewareTest.php
+++ b/tests/Unit/Middleware/FailureHandling/Implementation/SendAgainMiddlewareTest.php
@@ -8,7 +8,7 @@ use Exception;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureEnvelope;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
@@ -155,7 +155,7 @@ final class SendAgainMiddlewareTest extends TestCase
 
         $strategy = $this->getStrategy($strategyName, $queue);
         $request = new FailureHandlingRequest(
-            (new SimpleMessage(
+            (new GenericMessage(
                 'test',
                 null,
             ))->withMetadata([FailureEnvelope::FAILURE_META_KEY => $metaInitial]),

--- a/tests/Unit/Middleware/FailureHandling/Implementation/SendAgainMiddlewareTest.php
+++ b/tests/Unit/Middleware/FailureHandling/Implementation/SendAgainMiddlewareTest.php
@@ -8,7 +8,7 @@ use Exception;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureEnvelope;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
@@ -155,11 +155,10 @@ final class SendAgainMiddlewareTest extends TestCase
 
         $strategy = $this->getStrategy($strategyName, $queue);
         $request = new FailureHandlingRequest(
-            new Message(
+            (new SimpleMessage(
                 'test',
                 null,
-                [FailureEnvelope::FAILURE_META_KEY => $metaInitial],
-            ),
+            ))->withMetadata([FailureEnvelope::FAILURE_META_KEY => $metaInitial]),
             new Exception('testException'),
             $queue,
         );

--- a/tests/Unit/Middleware/FailureHandling/MiddlewareDispatcherTest.php
+++ b/tests/Unit/Middleware/FailureHandling/MiddlewareDispatcherTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Queue\Adapter\AdapterInterface;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureMiddlewareDispatcher;
@@ -30,7 +30,7 @@ final class MiddlewareDispatcherTest extends TestCase
             [
                 FailureMiddlewareDispatcher::DEFAULT_PIPELINE => [
                     static function (FailureHandlingRequest $request): FailureHandlingRequest {
-                        return $request->withMessage(new SimpleMessage('test', 'New closure test data'));
+                        return $request->withMessage(new GenericMessage('test', 'New closure test data'));
                     },
                 ],
             ],
@@ -77,12 +77,12 @@ final class MiddlewareDispatcherTest extends TestCase
         $request = $this->getFailureHandlingRequest();
 
         $middleware1 = static function (FailureHandlingRequest $request, FailureHandlerInterface $handler): FailureHandlingRequest {
-            $request = $request->withMessage(new SimpleMessage($request->getMessage()->getType(), 'new test data'));
+            $request = $request->withMessage(new GenericMessage($request->getMessage()->getType(), 'new test data'));
 
             return $handler->handleFailure($request);
         };
         $middleware2 = static function (FailureHandlingRequest $request, FailureHandlerInterface $handler): FailureHandlingRequest {
-            $request = $request->withMessage(new SimpleMessage('new handler', $request->getMessage()->getData()));
+            $request = $request->withMessage(new GenericMessage('new handler', $request->getMessage()->getData()));
 
             return $handler->handleFailure($request);
         };
@@ -99,10 +99,10 @@ final class MiddlewareDispatcherTest extends TestCase
         $request = $this->getFailureHandlingRequest();
 
         $middleware1 = static function (FailureHandlingRequest $request, FailureHandlerInterface $handler): FailureHandlingRequest {
-            return $request->withMessage(new SimpleMessage($request->getMessage()->getType(), 'first'));
+            return $request->withMessage(new GenericMessage($request->getMessage()->getType(), 'first'));
         };
         $middleware2 = static function (FailureHandlingRequest $request, FailureHandlerInterface $handler): FailureHandlingRequest {
-            return $request->withMessage(new SimpleMessage($request->getMessage()->getType(), 'second'));
+            return $request->withMessage(new GenericMessage($request->getMessage()->getType(), 'second'));
         };
 
         $dispatcher = $this->createDispatcher()->withMiddlewares([FailureMiddlewareDispatcher::DEFAULT_PIPELINE => [$middleware1, $middleware2]]);
@@ -173,7 +173,7 @@ final class MiddlewareDispatcherTest extends TestCase
     private function getFailureHandlingRequest(): FailureHandlingRequest
     {
         return new FailureHandlingRequest(
-            new SimpleMessage('handler', 'data'),
+            new GenericMessage('handler', 'data'),
             new Exception('Test exception.'),
             $this->createMock(QueueInterface::class),
         );

--- a/tests/Unit/Middleware/FailureHandling/MiddlewareDispatcherTest.php
+++ b/tests/Unit/Middleware/FailureHandling/MiddlewareDispatcherTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Queue\Adapter\AdapterInterface;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureMiddlewareDispatcher;
@@ -30,7 +30,7 @@ final class MiddlewareDispatcherTest extends TestCase
             [
                 FailureMiddlewareDispatcher::DEFAULT_PIPELINE => [
                     static function (FailureHandlingRequest $request): FailureHandlingRequest {
-                        return $request->withMessage(new Message('test', 'New closure test data'));
+                        return $request->withMessage(new SimpleMessage('test', 'New closure test data'));
                     },
                 ],
             ],
@@ -77,12 +77,12 @@ final class MiddlewareDispatcherTest extends TestCase
         $request = $this->getFailureHandlingRequest();
 
         $middleware1 = static function (FailureHandlingRequest $request, FailureHandlerInterface $handler): FailureHandlingRequest {
-            $request = $request->withMessage(new Message($request->getMessage()->getType(), 'new test data'));
+            $request = $request->withMessage(new SimpleMessage($request->getMessage()->getType(), 'new test data'));
 
             return $handler->handleFailure($request);
         };
         $middleware2 = static function (FailureHandlingRequest $request, FailureHandlerInterface $handler): FailureHandlingRequest {
-            $request = $request->withMessage(new Message('new handler', $request->getMessage()->getData()));
+            $request = $request->withMessage(new SimpleMessage('new handler', $request->getMessage()->getData()));
 
             return $handler->handleFailure($request);
         };
@@ -99,10 +99,10 @@ final class MiddlewareDispatcherTest extends TestCase
         $request = $this->getFailureHandlingRequest();
 
         $middleware1 = static function (FailureHandlingRequest $request, FailureHandlerInterface $handler): FailureHandlingRequest {
-            return $request->withMessage(new Message($request->getMessage()->getType(), 'first'));
+            return $request->withMessage(new SimpleMessage($request->getMessage()->getType(), 'first'));
         };
         $middleware2 = static function (FailureHandlingRequest $request, FailureHandlerInterface $handler): FailureHandlingRequest {
-            return $request->withMessage(new Message($request->getMessage()->getType(), 'second'));
+            return $request->withMessage(new SimpleMessage($request->getMessage()->getType(), 'second'));
         };
 
         $dispatcher = $this->createDispatcher()->withMiddlewares([FailureMiddlewareDispatcher::DEFAULT_PIPELINE => [$middleware1, $middleware2]]);
@@ -173,7 +173,7 @@ final class MiddlewareDispatcherTest extends TestCase
     private function getFailureHandlingRequest(): FailureHandlingRequest
     {
         return new FailureHandlingRequest(
-            new Message('handler', 'data'),
+            new SimpleMessage('handler', 'data'),
             new Exception('Test exception.'),
             $this->createMock(QueueInterface::class),
         );

--- a/tests/Unit/Middleware/FailureHandling/MiddlewareFactoryTest.php
+++ b/tests/Unit/Middleware/FailureHandling/MiddlewareFactoryTest.php
@@ -11,7 +11,7 @@ use Psr\Container\ContainerInterface;
 use RuntimeException;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Queue\Adapter\AdapterInterface;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlerInterface;
@@ -55,7 +55,7 @@ final class MiddlewareFactoryTest extends TestCase
         $middleware = $this->getMiddlewareFactory($container)->createFailureMiddleware(
             function (): FailureHandlingRequest {
                 return new FailureHandlingRequest(
-                    new SimpleMessage('test', 'test data'),
+                    new GenericMessage('test', 'test data'),
                     new RuntimeException('test exception'),
                     $this->createMock(QueueInterface::class),
                 );
@@ -206,7 +206,7 @@ final class MiddlewareFactoryTest extends TestCase
     private function getConsumeRequest(): FailureHandlingRequest
     {
         return new FailureHandlingRequest(
-            new SimpleMessage('handler', 'data'),
+            new GenericMessage('handler', 'data'),
             new Exception('test exception'),
             $this->createMock(QueueInterface::class),
         );

--- a/tests/Unit/Middleware/FailureHandling/MiddlewareFactoryTest.php
+++ b/tests/Unit/Middleware/FailureHandling/MiddlewareFactoryTest.php
@@ -11,7 +11,7 @@ use Psr\Container\ContainerInterface;
 use RuntimeException;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Queue\Adapter\AdapterInterface;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlerInterface;
@@ -55,7 +55,7 @@ final class MiddlewareFactoryTest extends TestCase
         $middleware = $this->getMiddlewareFactory($container)->createFailureMiddleware(
             function (): FailureHandlingRequest {
                 return new FailureHandlingRequest(
-                    new Message('test', 'test data'),
+                    new SimpleMessage('test', 'test data'),
                     new RuntimeException('test exception'),
                     $this->createMock(QueueInterface::class),
                 );
@@ -206,7 +206,7 @@ final class MiddlewareFactoryTest extends TestCase
     private function getConsumeRequest(): FailureHandlingRequest
     {
         return new FailureHandlingRequest(
-            new Message('handler', 'data'),
+            new SimpleMessage('handler', 'data'),
             new Exception('test exception'),
             $this->createMock(QueueInterface::class),
         );

--- a/tests/Unit/Middleware/FailureHandling/Support/CallableObjectMiddleware.php
+++ b/tests/Unit/Middleware/FailureHandling/Support/CallableObjectMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\FailureHandling\Support;
 
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 
 final class CallableObjectMiddleware
 {
     public function __invoke(FailureHandlingRequest $request): FailureHandlingRequest
     {
-        return $request->withMessage(new Message('test', 'Callable object data'));
+        return $request->withMessage(new SimpleMessage('test', 'Callable object data'));
     }
 }

--- a/tests/Unit/Middleware/FailureHandling/Support/CallableObjectMiddleware.php
+++ b/tests/Unit/Middleware/FailureHandling/Support/CallableObjectMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\FailureHandling\Support;
 
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 
 final class CallableObjectMiddleware
 {
     public function __invoke(FailureHandlingRequest $request): FailureHandlingRequest
     {
-        return $request->withMessage(new SimpleMessage('test', 'Callable object data'));
+        return $request->withMessage(new GenericMessage('test', 'Callable object data'));
     }
 }

--- a/tests/Unit/Middleware/FailureHandling/Support/StringCallableMiddleware.php
+++ b/tests/Unit/Middleware/FailureHandling/Support/StringCallableMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\FailureHandling\Support;
 
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 
 final class StringCallableMiddleware
 {
     public static function handle(FailureHandlingRequest $request): FailureHandlingRequest
     {
-        return $request->withMessage(new Message('test', 'String callable data'));
+        return $request->withMessage(new SimpleMessage('test', 'String callable data'));
     }
 }

--- a/tests/Unit/Middleware/FailureHandling/Support/StringCallableMiddleware.php
+++ b/tests/Unit/Middleware/FailureHandling/Support/StringCallableMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\FailureHandling\Support;
 
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 
 final class StringCallableMiddleware
 {
     public static function handle(FailureHandlingRequest $request): FailureHandlingRequest
     {
-        return $request->withMessage(new SimpleMessage('test', 'String callable data'));
+        return $request->withMessage(new GenericMessage('test', 'String callable data'));
     }
 }

--- a/tests/Unit/Middleware/FailureHandling/Support/TestCallableMiddleware.php
+++ b/tests/Unit/Middleware/FailureHandling/Support/TestCallableMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\FailureHandling\Support;
 
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 
 final class TestCallableMiddleware
 {
     public function index(FailureHandlingRequest $request): FailureHandlingRequest
     {
-        return $request->withMessage(new SimpleMessage('test', 'New test data'));
+        return $request->withMessage(new GenericMessage('test', 'New test data'));
     }
 }

--- a/tests/Unit/Middleware/FailureHandling/Support/TestCallableMiddleware.php
+++ b/tests/Unit/Middleware/FailureHandling/Support/TestCallableMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\FailureHandling\Support;
 
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 
 final class TestCallableMiddleware
 {
     public function index(FailureHandlingRequest $request): FailureHandlingRequest
     {
-        return $request->withMessage(new Message('test', 'New test data'));
+        return $request->withMessage(new SimpleMessage('test', 'New test data'));
     }
 }

--- a/tests/Unit/Middleware/FailureHandling/Support/TestMiddleware.php
+++ b/tests/Unit/Middleware/FailureHandling/Support/TestMiddleware.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\FailureHandling\Support;
 
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlerInterface;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureMiddlewareInterface;
@@ -15,6 +15,6 @@ final class TestMiddleware implements FailureMiddlewareInterface
 
     public function processFailure(FailureHandlingRequest $request, FailureHandlerInterface $handler): FailureHandlingRequest
     {
-        return $request->withMessage(new Message('test', $this->message));
+        return $request->withMessage(new SimpleMessage('test', $this->message));
     }
 }

--- a/tests/Unit/Middleware/FailureHandling/Support/TestMiddleware.php
+++ b/tests/Unit/Middleware/FailureHandling/Support/TestMiddleware.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\FailureHandling\Support;
 
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlingRequest;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureHandlerInterface;
 use Yiisoft\Queue\Middleware\FailureHandling\FailureMiddlewareInterface;
@@ -15,6 +15,6 @@ final class TestMiddleware implements FailureMiddlewareInterface
 
     public function processFailure(FailureHandlingRequest $request, FailureHandlerInterface $handler): FailureHandlingRequest
     {
-        return $request->withMessage(new SimpleMessage('test', $this->message));
+        return $request->withMessage(new GenericMessage('test', $this->message));
     }
 }

--- a/tests/Unit/Middleware/Push/AdapterPushHandlerTest.php
+++ b/tests/Unit/Middleware/Push/AdapterPushHandlerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Push;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\Push\AdapterPushHandler;
 use Yiisoft\Queue\Tests\App\FakeAdapter;
 
@@ -15,7 +15,7 @@ final class AdapterPushHandlerTest extends TestCase
     {
         $adapter = new FakeAdapter();
         $handler = new AdapterPushHandler($adapter);
-        $message = new Message('handler', 'data');
+        $message = new SimpleMessage('handler', 'data');
 
         $result = $handler->handlePush($message);
 

--- a/tests/Unit/Middleware/Push/AdapterPushHandlerTest.php
+++ b/tests/Unit/Middleware/Push/AdapterPushHandlerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Push;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\Push\AdapterPushHandler;
 use Yiisoft\Queue\Tests\App\FakeAdapter;
 
@@ -15,7 +15,7 @@ final class AdapterPushHandlerTest extends TestCase
     {
         $adapter = new FakeAdapter();
         $handler = new AdapterPushHandler($adapter);
-        $message = new SimpleMessage('handler', 'data');
+        $message = new GenericMessage('handler', 'data');
 
         $result = $handler->handlePush($message);
 

--- a/tests/Unit/Middleware/Push/Implementation/IdMiddlewareTest.php
+++ b/tests/Unit/Middleware/Push/Implementation/IdMiddlewareTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Queue\Tests\Unit\Middleware\Push\Implementation;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Message\IdEnvelope;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Middleware\Push\Implementation\IdMiddleware;
 use Yiisoft\Queue\Middleware\Push\PushHandlerInterface;
 
@@ -14,7 +14,7 @@ final class IdMiddlewareTest extends TestCase
 {
     public function testWithId(): void
     {
-        $message = (new SimpleMessage('test', null))->withMetadata([IdEnvelope::MESSAGE_ID_KEY => 'test-id']);
+        $message = (new GenericMessage('test', null))->withMetadata([IdEnvelope::MESSAGE_ID_KEY => 'test-id']);
         $handler = $this->createMock(PushHandlerInterface::class);
 
         $handler->expects($this->once())
@@ -33,7 +33,7 @@ final class IdMiddlewareTest extends TestCase
 
     public function testWithoutId(): void
     {
-        $message = new SimpleMessage('test', null);
+        $message = new GenericMessage('test', null);
         $handler = $this->createMock(PushHandlerInterface::class);
 
         $handler->expects($this->once())

--- a/tests/Unit/Middleware/Push/Implementation/IdMiddlewareTest.php
+++ b/tests/Unit/Middleware/Push/Implementation/IdMiddlewareTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Queue\Tests\Unit\Middleware\Push\Implementation;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Message\IdEnvelope;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Middleware\Push\Implementation\IdMiddleware;
 use Yiisoft\Queue\Middleware\Push\PushHandlerInterface;
 
@@ -14,7 +14,7 @@ final class IdMiddlewareTest extends TestCase
 {
     public function testWithId(): void
     {
-        $message = new Message('test', null, [IdEnvelope::MESSAGE_ID_KEY => 'test-id']);
+        $message = (new SimpleMessage('test', null))->withMetadata([IdEnvelope::MESSAGE_ID_KEY => 'test-id']);
         $handler = $this->createMock(PushHandlerInterface::class);
 
         $handler->expects($this->once())
@@ -33,7 +33,7 @@ final class IdMiddlewareTest extends TestCase
 
     public function testWithoutId(): void
     {
-        $message = new Message('test', null);
+        $message = new SimpleMessage('test', null);
         $handler = $this->createMock(PushHandlerInterface::class);
 
         $handler->expects($this->once())

--- a/tests/Unit/Middleware/Push/MiddlewareDispatcherTest.php
+++ b/tests/Unit/Middleware/Push/MiddlewareDispatcherTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Queue\Adapter\AdapterInterface;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Push\PushHandlerInterface;
@@ -28,7 +28,7 @@ final class MiddlewareDispatcherTest extends TestCase
         $dispatcher = $this->createDispatcher()->withMiddlewares(
             [
                 static function (MessageInterface $message, PushHandlerInterface $handler): MessageInterface {
-                    return new Message('test', 'New closure test data');
+                    return new SimpleMessage('test', 'New closure test data');
                 },
             ],
         );
@@ -68,7 +68,7 @@ final class MiddlewareDispatcherTest extends TestCase
         $message = $this->getMessage();
 
         $middleware1 = static function (MessageInterface $message, PushHandlerInterface $handler): MessageInterface {
-            return $handler->handlePush(new Message($message->getType(), 'new test data'));
+            return $handler->handlePush(new SimpleMessage($message->getType(), 'new test data'));
         };
         $middleware2 = static function (MessageInterface $message, PushHandlerInterface $handler): MessageInterface {
             return $handler->handlePush($message);
@@ -84,8 +84,8 @@ final class MiddlewareDispatcherTest extends TestCase
     {
         $message = $this->getMessage();
 
-        $middleware1 = static fn(MessageInterface $message, PushHandlerInterface $handler): MessageInterface => new Message($message->getType(), 'first');
-        $middleware2 = static fn(MessageInterface $message, PushHandlerInterface $handler): MessageInterface => new Message($message->getType(), 'second');
+        $middleware1 = static fn(MessageInterface $message, PushHandlerInterface $handler): MessageInterface => new SimpleMessage($message->getType(), 'first');
+        $middleware2 = static fn(MessageInterface $message, PushHandlerInterface $handler): MessageInterface => new SimpleMessage($message->getType(), 'second');
 
         $dispatcher = $this->createDispatcher()->withMiddlewares([$middleware1, $middleware2]);
 
@@ -162,6 +162,6 @@ final class MiddlewareDispatcherTest extends TestCase
 
     private function getMessage(): MessageInterface
     {
-        return new Message('handler', 'data');
+        return new SimpleMessage('handler', 'data');
     }
 }

--- a/tests/Unit/Middleware/Push/MiddlewareDispatcherTest.php
+++ b/tests/Unit/Middleware/Push/MiddlewareDispatcherTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Queue\Adapter\AdapterInterface;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\Push\PushHandlerInterface;
@@ -28,7 +28,7 @@ final class MiddlewareDispatcherTest extends TestCase
         $dispatcher = $this->createDispatcher()->withMiddlewares(
             [
                 static function (MessageInterface $message, PushHandlerInterface $handler): MessageInterface {
-                    return new SimpleMessage('test', 'New closure test data');
+                    return new GenericMessage('test', 'New closure test data');
                 },
             ],
         );
@@ -68,7 +68,7 @@ final class MiddlewareDispatcherTest extends TestCase
         $message = $this->getMessage();
 
         $middleware1 = static function (MessageInterface $message, PushHandlerInterface $handler): MessageInterface {
-            return $handler->handlePush(new SimpleMessage($message->getType(), 'new test data'));
+            return $handler->handlePush(new GenericMessage($message->getType(), 'new test data'));
         };
         $middleware2 = static function (MessageInterface $message, PushHandlerInterface $handler): MessageInterface {
             return $handler->handlePush($message);
@@ -84,8 +84,8 @@ final class MiddlewareDispatcherTest extends TestCase
     {
         $message = $this->getMessage();
 
-        $middleware1 = static fn(MessageInterface $message, PushHandlerInterface $handler): MessageInterface => new SimpleMessage($message->getType(), 'first');
-        $middleware2 = static fn(MessageInterface $message, PushHandlerInterface $handler): MessageInterface => new SimpleMessage($message->getType(), 'second');
+        $middleware1 = static fn(MessageInterface $message, PushHandlerInterface $handler): MessageInterface => new GenericMessage($message->getType(), 'first');
+        $middleware2 = static fn(MessageInterface $message, PushHandlerInterface $handler): MessageInterface => new GenericMessage($message->getType(), 'second');
 
         $dispatcher = $this->createDispatcher()->withMiddlewares([$middleware1, $middleware2]);
 
@@ -162,6 +162,6 @@ final class MiddlewareDispatcherTest extends TestCase
 
     private function getMessage(): MessageInterface
     {
-        return new SimpleMessage('handler', 'data');
+        return new GenericMessage('handler', 'data');
     }
 }

--- a/tests/Unit/Middleware/Push/MiddlewareFactoryTest.php
+++ b/tests/Unit/Middleware/Push/MiddlewareFactoryTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Queue\Adapter\AdapterInterface;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\InvalidMiddlewareDefinitionException;
@@ -51,7 +51,7 @@ final class MiddlewareFactoryTest extends TestCase
         $container = $this->getContainer([TestCallableMiddleware::class => new TestCallableMiddleware()]);
         $middleware = $this->getMiddlewareFactory($container)->createPushMiddleware(
             static function (): MessageInterface {
-                return new Message('test', 'test data');
+                return new SimpleMessage('test', 'test data');
             },
         );
         self::assertSame(
@@ -195,6 +195,6 @@ final class MiddlewareFactoryTest extends TestCase
 
     private function getMessage(): MessageInterface
     {
-        return new Message('handler', 'data');
+        return new SimpleMessage('handler', 'data');
     }
 }

--- a/tests/Unit/Middleware/Push/MiddlewareFactoryTest.php
+++ b/tests/Unit/Middleware/Push/MiddlewareFactoryTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Queue\Adapter\AdapterInterface;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\CallableFactory;
 use Yiisoft\Queue\Middleware\InvalidMiddlewareDefinitionException;
@@ -51,7 +51,7 @@ final class MiddlewareFactoryTest extends TestCase
         $container = $this->getContainer([TestCallableMiddleware::class => new TestCallableMiddleware()]);
         $middleware = $this->getMiddlewareFactory($container)->createPushMiddleware(
             static function (): MessageInterface {
-                return new SimpleMessage('test', 'test data');
+                return new GenericMessage('test', 'test data');
             },
         );
         self::assertSame(
@@ -195,6 +195,6 @@ final class MiddlewareFactoryTest extends TestCase
 
     private function getMessage(): MessageInterface
     {
-        return new SimpleMessage('handler', 'data');
+        return new GenericMessage('handler', 'data');
     }
 }

--- a/tests/Unit/Middleware/Push/Support/CallableObjectMiddleware.php
+++ b/tests/Unit/Middleware/Push/Support/CallableObjectMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Push\Support;
 
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 
 final class CallableObjectMiddleware
 {
     public function __invoke(MessageInterface $message): MessageInterface
     {
-        return new SimpleMessage('test', 'Callable object data');
+        return new GenericMessage('test', 'Callable object data');
     }
 }

--- a/tests/Unit/Middleware/Push/Support/CallableObjectMiddleware.php
+++ b/tests/Unit/Middleware/Push/Support/CallableObjectMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Push\Support;
 
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 
 final class CallableObjectMiddleware
 {
     public function __invoke(MessageInterface $message): MessageInterface
     {
-        return new Message('test', 'Callable object data');
+        return new SimpleMessage('test', 'Callable object data');
     }
 }

--- a/tests/Unit/Middleware/Push/Support/StringCallableMiddleware.php
+++ b/tests/Unit/Middleware/Push/Support/StringCallableMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Push\Support;
 
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 
 final class StringCallableMiddleware
 {
     public static function handle(MessageInterface $message): MessageInterface
     {
-        return new Message('test', 'String callable data');
+        return new SimpleMessage('test', 'String callable data');
     }
 }

--- a/tests/Unit/Middleware/Push/Support/StringCallableMiddleware.php
+++ b/tests/Unit/Middleware/Push/Support/StringCallableMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Push\Support;
 
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 
 final class StringCallableMiddleware
 {
     public static function handle(MessageInterface $message): MessageInterface
     {
-        return new SimpleMessage('test', 'String callable data');
+        return new GenericMessage('test', 'String callable data');
     }
 }

--- a/tests/Unit/Middleware/Push/Support/TestCallableMiddleware.php
+++ b/tests/Unit/Middleware/Push/Support/TestCallableMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Push\Support;
 
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 
 final class TestCallableMiddleware
 {
     public function index(MessageInterface $message): MessageInterface
     {
-        return new SimpleMessage('test', 'New test data');
+        return new GenericMessage('test', 'New test data');
     }
 }

--- a/tests/Unit/Middleware/Push/Support/TestCallableMiddleware.php
+++ b/tests/Unit/Middleware/Push/Support/TestCallableMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Push\Support;
 
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 
 final class TestCallableMiddleware
 {
     public function index(MessageInterface $message): MessageInterface
     {
-        return new Message('test', 'New test data');
+        return new SimpleMessage('test', 'New test data');
     }
 }

--- a/tests/Unit/Middleware/Push/Support/TestMiddleware.php
+++ b/tests/Unit/Middleware/Push/Support/TestMiddleware.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Push\Support;
 
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\Push\PushHandlerInterface;
 use Yiisoft\Queue\Middleware\Push\PushMiddlewareInterface;
@@ -15,6 +15,6 @@ final class TestMiddleware implements PushMiddlewareInterface
 
     public function processPush(MessageInterface $message, PushHandlerInterface $handler): MessageInterface
     {
-        return new Message('test', $this->message);
+        return new SimpleMessage('test', $this->message);
     }
 }

--- a/tests/Unit/Middleware/Push/Support/TestMiddleware.php
+++ b/tests/Unit/Middleware/Push/Support/TestMiddleware.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Middleware\Push\Support;
 
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\Push\PushHandlerInterface;
 use Yiisoft\Queue\Middleware\Push\PushMiddlewareInterface;
@@ -15,6 +15,6 @@ final class TestMiddleware implements PushMiddlewareInterface
 
     public function processPush(MessageInterface $message, PushHandlerInterface $handler): MessageInterface
     {
-        return new SimpleMessage('test', $this->message);
+        return new GenericMessage('test', $this->message);
     }
 }

--- a/tests/Unit/QueueTest.php
+++ b/tests/Unit/QueueTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Queue\Tests\Unit;
 
 use Yiisoft\Queue\Cli\SignalLoop;
 use Yiisoft\Queue\Message\IdEnvelope;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\MessageStatus;
 use Yiisoft\Queue\Stubs\InMemoryAdapter;
 use Yiisoft\Queue\Tests\App\FakeAdapter;
@@ -27,7 +27,7 @@ final class QueueTest extends TestCase
     {
         $adapter = new FakeAdapter();
         $queue = $this->createQueue($adapter);
-        $message = new Message('simple', null);
+        $message = new SimpleMessage('simple', null);
         $queue->push($message);
 
         self::assertSame([$message], $adapter->pushMessages);
@@ -36,7 +36,7 @@ final class QueueTest extends TestCase
     public function testPushSynchronouslyProcessesMessage(): void
     {
         $queue = $this->createQueue();
-        $message = new Message('simple', null);
+        $message = new SimpleMessage('simple', null);
 
         $queue->push($message);
         $queue->push(clone $message);
@@ -47,7 +47,7 @@ final class QueueTest extends TestCase
     public function testRunWithoutAdapterReturnsZero(): void
     {
         $queue = $this->createQueue();
-        $message = new Message('simple', null);
+        $message = new SimpleMessage('simple', null);
         $queue->push($message);
         $queue->push(clone $message);
 
@@ -74,7 +74,7 @@ final class QueueTest extends TestCase
     public function testRunWithAdapter(): void
     {
         $queue = $this->createQueue(new InMemoryAdapter());
-        $message = new Message('simple', null);
+        $message = new SimpleMessage('simple', null);
         $queue->push($message);
         $queue->push(clone $message);
 
@@ -85,7 +85,7 @@ final class QueueTest extends TestCase
     public function testRunPartlyWithAdapter(): void
     {
         $queue = $this->createQueue(new InMemoryAdapter());
-        $message = new Message('simple', null);
+        $message = new SimpleMessage('simple', null);
         $queue->push($message);
         $queue->push(clone $message);
 
@@ -96,7 +96,7 @@ final class QueueTest extends TestCase
     public function testListenWithAdapter(): void
     {
         $queue = $this->createQueue(new InMemoryAdapter());
-        $message = new Message('simple', null);
+        $message = new SimpleMessage('simple', null);
         $queue->push($message);
         $queue->push(clone $message);
 
@@ -108,7 +108,7 @@ final class QueueTest extends TestCase
     public function testStatusWithAdapter(): void
     {
         $queue = $this->createQueue(new InMemoryAdapter());
-        $envelope = $queue->push(new Message('simple', null));
+        $envelope = $queue->push(new SimpleMessage('simple', null));
 
         self::assertArrayHasKey(IdEnvelope::MESSAGE_ID_KEY, $envelope->getMetadata());
         /** @var int|string $id */
@@ -128,7 +128,7 @@ final class QueueTest extends TestCase
 
         $this->loop = new SignalLoop();
         $queue = $this->createQueue();
-        $message = new Message('simple', null);
+        $message = new SimpleMessage('simple', null);
         $queue->push($message);
         $queue->push(clone $message);
 

--- a/tests/Unit/QueueTest.php
+++ b/tests/Unit/QueueTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Queue\Tests\Unit;
 
 use Yiisoft\Queue\Cli\SignalLoop;
 use Yiisoft\Queue\Message\IdEnvelope;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\MessageStatus;
 use Yiisoft\Queue\Stubs\InMemoryAdapter;
 use Yiisoft\Queue\Tests\App\FakeAdapter;
@@ -27,7 +27,7 @@ final class QueueTest extends TestCase
     {
         $adapter = new FakeAdapter();
         $queue = $this->createQueue($adapter);
-        $message = new SimpleMessage('simple', null);
+        $message = new GenericMessage('simple', null);
         $queue->push($message);
 
         self::assertSame([$message], $adapter->pushMessages);
@@ -36,7 +36,7 @@ final class QueueTest extends TestCase
     public function testPushSynchronouslyProcessesMessage(): void
     {
         $queue = $this->createQueue();
-        $message = new SimpleMessage('simple', null);
+        $message = new GenericMessage('simple', null);
 
         $queue->push($message);
         $queue->push(clone $message);
@@ -47,7 +47,7 @@ final class QueueTest extends TestCase
     public function testRunWithoutAdapterReturnsZero(): void
     {
         $queue = $this->createQueue();
-        $message = new SimpleMessage('simple', null);
+        $message = new GenericMessage('simple', null);
         $queue->push($message);
         $queue->push(clone $message);
 
@@ -74,7 +74,7 @@ final class QueueTest extends TestCase
     public function testRunWithAdapter(): void
     {
         $queue = $this->createQueue(new InMemoryAdapter());
-        $message = new SimpleMessage('simple', null);
+        $message = new GenericMessage('simple', null);
         $queue->push($message);
         $queue->push(clone $message);
 
@@ -85,7 +85,7 @@ final class QueueTest extends TestCase
     public function testRunPartlyWithAdapter(): void
     {
         $queue = $this->createQueue(new InMemoryAdapter());
-        $message = new SimpleMessage('simple', null);
+        $message = new GenericMessage('simple', null);
         $queue->push($message);
         $queue->push(clone $message);
 
@@ -96,7 +96,7 @@ final class QueueTest extends TestCase
     public function testListenWithAdapter(): void
     {
         $queue = $this->createQueue(new InMemoryAdapter());
-        $message = new SimpleMessage('simple', null);
+        $message = new GenericMessage('simple', null);
         $queue->push($message);
         $queue->push(clone $message);
 
@@ -108,7 +108,7 @@ final class QueueTest extends TestCase
     public function testStatusWithAdapter(): void
     {
         $queue = $this->createQueue(new InMemoryAdapter());
-        $envelope = $queue->push(new SimpleMessage('simple', null));
+        $envelope = $queue->push(new GenericMessage('simple', null));
 
         self::assertArrayHasKey(IdEnvelope::MESSAGE_ID_KEY, $envelope->getMetadata());
         /** @var int|string $id */
@@ -128,7 +128,7 @@ final class QueueTest extends TestCase
 
         $this->loop = new SignalLoop();
         $queue = $this->createQueue();
-        $message = new SimpleMessage('simple', null);
+        $message = new GenericMessage('simple', null);
         $queue->push($message);
         $queue->push(clone $message);
 

--- a/tests/Unit/Stubs/InMemoryAdapterTest.php
+++ b/tests/Unit/Stubs/InMemoryAdapterTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Queue\Tests\Unit\Stubs;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Message\IdEnvelope;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\MessageStatus;
 use Yiisoft\Queue\Stubs\InMemoryAdapter;
@@ -17,9 +17,9 @@ final class InMemoryAdapterTest extends TestCase
     {
         $adapter = new InMemoryAdapter();
 
-        $envelope1 = $adapter->push(new SimpleMessage('test', 'a'));
-        $envelope2 = $adapter->push(new SimpleMessage('test', 'b'));
-        $envelope3 = $adapter->push(new SimpleMessage('test', 'c'));
+        $envelope1 = $adapter->push(new GenericMessage('test', 'a'));
+        $envelope2 = $adapter->push(new GenericMessage('test', 'b'));
+        $envelope3 = $adapter->push(new GenericMessage('test', 'c'));
 
         $this->assertInstanceOf(IdEnvelope::class, $envelope1);
         $this->assertInstanceOf(IdEnvelope::class, $envelope2);
@@ -36,7 +36,7 @@ final class InMemoryAdapterTest extends TestCase
     public function testStatusWaitingForPushedMessage(): void
     {
         $adapter = new InMemoryAdapter();
-        $envelope = $adapter->push(new SimpleMessage('test', null));
+        $envelope = $adapter->push(new GenericMessage('test', null));
 
         $this->assertInstanceOf(IdEnvelope::class, $envelope);
         $this->assertSame(MessageStatus::WAITING, $adapter->status($envelope->getId()));
@@ -45,7 +45,7 @@ final class InMemoryAdapterTest extends TestCase
     public function testStatusDoneAfterProcessing(): void
     {
         $adapter = new InMemoryAdapter();
-        $envelope = $adapter->push(new SimpleMessage('test', null));
+        $envelope = $adapter->push(new GenericMessage('test', null));
 
         $adapter->runExisting(static fn() => true);
 
@@ -70,7 +70,7 @@ final class InMemoryAdapterTest extends TestCase
     public function testStatusAcceptsStringId(): void
     {
         $adapter = new InMemoryAdapter();
-        $envelope = $adapter->push(new SimpleMessage('test', null));
+        $envelope = $adapter->push(new GenericMessage('test', null));
 
         $this->assertInstanceOf(IdEnvelope::class, $envelope);
         $this->assertSame(MessageStatus::WAITING, $adapter->status((string) $envelope->getId()));
@@ -79,9 +79,9 @@ final class InMemoryAdapterTest extends TestCase
     public function testRunExistingProcessesAllMessages(): void
     {
         $adapter = new InMemoryAdapter();
-        $adapter->push(new SimpleMessage('test', 'a'));
-        $adapter->push(new SimpleMessage('test', 'b'));
-        $adapter->push(new SimpleMessage('test', 'c'));
+        $adapter->push(new GenericMessage('test', 'a'));
+        $adapter->push(new GenericMessage('test', 'b'));
+        $adapter->push(new GenericMessage('test', 'c'));
 
         $processed = [];
         $adapter->runExisting(
@@ -97,9 +97,9 @@ final class InMemoryAdapterTest extends TestCase
     public function testRunExistingStopsWhenHandlerReturnsFalse(): void
     {
         $adapter = new InMemoryAdapter();
-        $adapter->push(new SimpleMessage('test', 'a'));
-        $adapter->push(new SimpleMessage('test', 'b'));
-        $adapter->push(new SimpleMessage('test', 'c'));
+        $adapter->push(new GenericMessage('test', 'a'));
+        $adapter->push(new GenericMessage('test', 'b'));
+        $adapter->push(new GenericMessage('test', 'c'));
 
         $processed = [];
         $adapter->runExisting(
@@ -128,7 +128,7 @@ final class InMemoryAdapterTest extends TestCase
     public function testRunExistingDoesNotReprocessMessages(): void
     {
         $adapter = new InMemoryAdapter();
-        $adapter->push(new SimpleMessage('test', 'x'));
+        $adapter->push(new GenericMessage('test', 'x'));
 
         $count = 0;
         $handler = static function () use (&$count): bool {
@@ -144,10 +144,10 @@ final class InMemoryAdapterTest extends TestCase
     public function testIdContinuesAfterProcessing(): void
     {
         $adapter = new InMemoryAdapter();
-        $adapter->push(new SimpleMessage('test', null));
+        $adapter->push(new GenericMessage('test', null));
         $adapter->runExisting(static fn() => true);
 
-        $envelope = $adapter->push(new SimpleMessage('test', null));
+        $envelope = $adapter->push(new GenericMessage('test', null));
 
         $this->assertInstanceOf(IdEnvelope::class, $envelope);
         $this->assertSame(1, $envelope->getId());
@@ -157,8 +157,8 @@ final class InMemoryAdapterTest extends TestCase
     public function testSubscribeProcessesExistingMessages(): void
     {
         $adapter = new InMemoryAdapter();
-        $adapter->push(new SimpleMessage('test', 'a'));
-        $adapter->push(new SimpleMessage('test', 'b'));
+        $adapter->push(new GenericMessage('test', 'a'));
+        $adapter->push(new GenericMessage('test', 'b'));
 
         $processed = [];
         $adapter->subscribe(

--- a/tests/Unit/Stubs/InMemoryAdapterTest.php
+++ b/tests/Unit/Stubs/InMemoryAdapterTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Queue\Tests\Unit\Stubs;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\Message\IdEnvelope;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\MessageStatus;
 use Yiisoft\Queue\Stubs\InMemoryAdapter;
@@ -17,9 +17,9 @@ final class InMemoryAdapterTest extends TestCase
     {
         $adapter = new InMemoryAdapter();
 
-        $envelope1 = $adapter->push(new Message('test', 'a'));
-        $envelope2 = $adapter->push(new Message('test', 'b'));
-        $envelope3 = $adapter->push(new Message('test', 'c'));
+        $envelope1 = $adapter->push(new SimpleMessage('test', 'a'));
+        $envelope2 = $adapter->push(new SimpleMessage('test', 'b'));
+        $envelope3 = $adapter->push(new SimpleMessage('test', 'c'));
 
         $this->assertInstanceOf(IdEnvelope::class, $envelope1);
         $this->assertInstanceOf(IdEnvelope::class, $envelope2);
@@ -36,7 +36,7 @@ final class InMemoryAdapterTest extends TestCase
     public function testStatusWaitingForPushedMessage(): void
     {
         $adapter = new InMemoryAdapter();
-        $envelope = $adapter->push(new Message('test', null));
+        $envelope = $adapter->push(new SimpleMessage('test', null));
 
         $this->assertInstanceOf(IdEnvelope::class, $envelope);
         $this->assertSame(MessageStatus::WAITING, $adapter->status($envelope->getId()));
@@ -45,7 +45,7 @@ final class InMemoryAdapterTest extends TestCase
     public function testStatusDoneAfterProcessing(): void
     {
         $adapter = new InMemoryAdapter();
-        $envelope = $adapter->push(new Message('test', null));
+        $envelope = $adapter->push(new SimpleMessage('test', null));
 
         $adapter->runExisting(static fn() => true);
 
@@ -70,7 +70,7 @@ final class InMemoryAdapterTest extends TestCase
     public function testStatusAcceptsStringId(): void
     {
         $adapter = new InMemoryAdapter();
-        $envelope = $adapter->push(new Message('test', null));
+        $envelope = $adapter->push(new SimpleMessage('test', null));
 
         $this->assertInstanceOf(IdEnvelope::class, $envelope);
         $this->assertSame(MessageStatus::WAITING, $adapter->status((string) $envelope->getId()));
@@ -79,9 +79,9 @@ final class InMemoryAdapterTest extends TestCase
     public function testRunExistingProcessesAllMessages(): void
     {
         $adapter = new InMemoryAdapter();
-        $adapter->push(new Message('test', 'a'));
-        $adapter->push(new Message('test', 'b'));
-        $adapter->push(new Message('test', 'c'));
+        $adapter->push(new SimpleMessage('test', 'a'));
+        $adapter->push(new SimpleMessage('test', 'b'));
+        $adapter->push(new SimpleMessage('test', 'c'));
 
         $processed = [];
         $adapter->runExisting(
@@ -97,9 +97,9 @@ final class InMemoryAdapterTest extends TestCase
     public function testRunExistingStopsWhenHandlerReturnsFalse(): void
     {
         $adapter = new InMemoryAdapter();
-        $adapter->push(new Message('test', 'a'));
-        $adapter->push(new Message('test', 'b'));
-        $adapter->push(new Message('test', 'c'));
+        $adapter->push(new SimpleMessage('test', 'a'));
+        $adapter->push(new SimpleMessage('test', 'b'));
+        $adapter->push(new SimpleMessage('test', 'c'));
 
         $processed = [];
         $adapter->runExisting(
@@ -128,7 +128,7 @@ final class InMemoryAdapterTest extends TestCase
     public function testRunExistingDoesNotReprocessMessages(): void
     {
         $adapter = new InMemoryAdapter();
-        $adapter->push(new Message('test', 'x'));
+        $adapter->push(new SimpleMessage('test', 'x'));
 
         $count = 0;
         $handler = static function () use (&$count): bool {
@@ -144,10 +144,10 @@ final class InMemoryAdapterTest extends TestCase
     public function testIdContinuesAfterProcessing(): void
     {
         $adapter = new InMemoryAdapter();
-        $adapter->push(new Message('test', null));
+        $adapter->push(new SimpleMessage('test', null));
         $adapter->runExisting(static fn() => true);
 
-        $envelope = $adapter->push(new Message('test', null));
+        $envelope = $adapter->push(new SimpleMessage('test', null));
 
         $this->assertInstanceOf(IdEnvelope::class, $envelope);
         $this->assertSame(1, $envelope->getId());
@@ -157,8 +157,8 @@ final class InMemoryAdapterTest extends TestCase
     public function testSubscribeProcessesExistingMessages(): void
     {
         $adapter = new InMemoryAdapter();
-        $adapter->push(new Message('test', 'a'));
-        $adapter->push(new Message('test', 'b'));
+        $adapter->push(new SimpleMessage('test', 'a'));
+        $adapter->push(new SimpleMessage('test', 'b'));
 
         $processed = [];
         $adapter->subscribe(

--- a/tests/Unit/Stubs/StubQueueTest.php
+++ b/tests/Unit/Stubs/StubQueueTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Queue\Tests\Unit\Stubs;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\MessageStatus;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Stubs\StubQueue;
 
 final class StubQueueTest extends TestCase
@@ -14,7 +14,7 @@ final class StubQueueTest extends TestCase
     public function testBase(): void
     {
         $queue = new StubQueue();
-        $message = new SimpleMessage('test', 42);
+        $message = new GenericMessage('test', 42);
 
         $this->assertSame($message, $queue->push($message));
         $this->assertSame(0, $queue->run());

--- a/tests/Unit/Stubs/StubQueueTest.php
+++ b/tests/Unit/Stubs/StubQueueTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Queue\Tests\Unit\Stubs;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\MessageStatus;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Stubs\StubQueue;
 
 final class StubQueueTest extends TestCase
@@ -14,7 +14,7 @@ final class StubQueueTest extends TestCase
     public function testBase(): void
     {
         $queue = new StubQueue();
-        $message = new Message('test', 42);
+        $message = new SimpleMessage('test', 42);
 
         $this->assertSame($message, $queue->push($message));
         $this->assertSame(0, $queue->run());

--- a/tests/Unit/Stubs/StubWorkerTest.php
+++ b/tests/Unit/Stubs/StubWorkerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Queue\Tests\Unit\Stubs;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\QueueInterface;
 use Yiisoft\Queue\Stubs\StubWorker;
 
@@ -15,7 +15,7 @@ final class StubWorkerTest extends TestCase
     {
         $worker = new StubWorker();
 
-        $sourceMessage = new SimpleMessage('test', 42);
+        $sourceMessage = new GenericMessage('test', 42);
 
         $message = $worker->process($sourceMessage, $this->createMock(QueueInterface::class));
 

--- a/tests/Unit/Stubs/StubWorkerTest.php
+++ b/tests/Unit/Stubs/StubWorkerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Queue\Tests\Unit\Stubs;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\QueueInterface;
 use Yiisoft\Queue\Stubs\StubWorker;
 
@@ -15,7 +15,7 @@ final class StubWorkerTest extends TestCase
     {
         $worker = new StubWorker();
 
-        $sourceMessage = new Message('test', 42);
+        $sourceMessage = new SimpleMessage('test', 42);
 
         $message = $worker->process($sourceMessage, $this->createMock(QueueInterface::class));
 

--- a/tests/Unit/Support/TestMessage.php
+++ b/tests/Unit/Support/TestMessage.php
@@ -9,7 +9,7 @@ use Yiisoft\Queue\Message\MessageInterface;
 
 final class TestMessage extends Message
 {
-    public static function fromData(string $type, mixed $data, array $metadata = []): MessageInterface
+    public static function fromData(string $type, mixed $data): MessageInterface
     {
         return new self();
     }

--- a/tests/Unit/Support/TestMessage.php
+++ b/tests/Unit/Support/TestMessage.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Support;
 
+use Yiisoft\Queue\Message\Message;
 use Yiisoft\Queue\Message\MessageInterface;
 
-final class TestMessage implements MessageInterface
+final class TestMessage extends Message
 {
     public static function fromData(string $type, mixed $data, array $metadata = []): MessageInterface
     {
@@ -21,10 +22,5 @@ final class TestMessage implements MessageInterface
     public function getData(): mixed
     {
         return null;
-    }
-
-    public function getMetadata(): array
-    {
-        return [];
     }
 }

--- a/tests/Unit/WorkerTest.php
+++ b/tests/Unit/WorkerTest.php
@@ -13,7 +13,7 @@ use Yiisoft\Injector\Injector;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Test\Support\Log\SimpleLogger;
 use Yiisoft\Queue\Exception\MessageFailureException;
-use Yiisoft\Queue\Message\SimpleMessage;
+use Yiisoft\Queue\Message\GenericMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareDispatcher;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareFactoryInterface;
@@ -35,7 +35,7 @@ final class WorkerTest extends TestCase
     #[DataProvider('messageHandledDataProvider')]
     public function testMessageHandled(mixed $handler, array $containerServices): void
     {
-        $message = new SimpleMessage('simple', ['test-data']);
+        $message = new GenericMessage('simple', ['test-data']);
         $logger = new SimpleLogger();
         $container = new SimpleContainer($containerServices);
         $handlers = ['simple' => $handler];
@@ -90,7 +90,7 @@ final class WorkerTest extends TestCase
     {
         $this->expectExceptionMessage('Queue handler for message type "simple" does not exist');
 
-        $message = new SimpleMessage('simple', ['test-data']);
+        $message = new GenericMessage('simple', ['test-data']);
         $handler = new FakeHandler();
         $container = new SimpleContainer([FakeHandler::class => $handler]);
         $handlers = ['simple' => [FakeHandler::class, 'undefinedMethod']];
@@ -106,7 +106,7 @@ final class WorkerTest extends TestCase
     {
         $this->expectExceptionMessage('Queue handler for message type "simple" does not exist');
 
-        $message = new SimpleMessage('simple', ['test-data']);
+        $message = new GenericMessage('simple', ['test-data']);
         $logger = new SimpleLogger();
         $handler = new FakeHandler();
         $container = new SimpleContainer([FakeHandler::class => $handler]);
@@ -122,7 +122,7 @@ final class WorkerTest extends TestCase
     public function testMessageFailWithDefinitionClassNotFoundInContainerHandler(): void
     {
         $this->expectExceptionMessage('Queue handler for message type "simple" does not exist');
-        $message = new SimpleMessage('simple', ['test-data']);
+        $message = new GenericMessage('simple', ['test-data']);
         $container = new SimpleContainer();
         $handlers = ['simple' => [FakeHandler::class, 'handle']];
 
@@ -135,7 +135,7 @@ final class WorkerTest extends TestCase
 
     public function testMessageFailWithDefinitionHandlerException(): void
     {
-        $message = new SimpleMessage('simple', ['test-data']);
+        $message = new GenericMessage('simple', ['test-data']);
         $logger = new SimpleLogger();
         $handler = new FakeHandler();
         $container = new SimpleContainer([FakeHandler::class => $handler]);
@@ -163,7 +163,7 @@ final class WorkerTest extends TestCase
 
     public function testHandlerNotFoundInContainer(): void
     {
-        $message = new SimpleMessage('nonexistent', ['test-data']);
+        $message = new GenericMessage('nonexistent', ['test-data']);
         $container = new SimpleContainer();
         $handlers = [];
 
@@ -178,7 +178,7 @@ final class WorkerTest extends TestCase
 
     public function testHandlerInContainerNotImplementingInterface(): void
     {
-        $message = new SimpleMessage('invalid', ['test-data']);
+        $message = new GenericMessage('invalid', ['test-data']);
         $container = new SimpleContainer([
             'invalid' => new class {
                 public function handle(): void {}
@@ -197,7 +197,7 @@ final class WorkerTest extends TestCase
 
     public function testMessageFailureIsHandledSuccessfully(): void
     {
-        $message = new SimpleMessage('simple', null);
+        $message = new GenericMessage('simple', null);
         /** @var MockObject&QueueInterface $queue */
         $queue = $this->createMock(QueueInterface::class);
         $queue->method('getName')->willReturn('test-queue');
@@ -212,7 +212,7 @@ final class WorkerTest extends TestCase
         $consumeMiddlewareFactory->method('createConsumeMiddleware')->willReturn($consumeMiddleware);
         $consumeDispatcher = new ConsumeMiddlewareDispatcher($consumeMiddlewareFactory, 'simple');
 
-        $finalMessage = new SimpleMessage('final', null);
+        $finalMessage = new GenericMessage('final', null);
         /** @var FailureMiddlewareInterface&MockObject $failureMiddleware */
         $failureMiddleware = $this->createMock(FailureMiddlewareInterface::class);
         $failureMiddleware->method('processFailure')->willReturn(new FailureHandlingRequest($finalMessage, $originalException, $queue));
@@ -240,7 +240,7 @@ final class WorkerTest extends TestCase
 
     public function testStaticMethodHandler(): void
     {
-        $message = new SimpleMessage('static-handler', ['test-data']);
+        $message = new GenericMessage('static-handler', ['test-data']);
         $container = new SimpleContainer();
         $handlers = [
             'static-handler' => StaticMessageHandler::handle(...),

--- a/tests/Unit/WorkerTest.php
+++ b/tests/Unit/WorkerTest.php
@@ -13,7 +13,7 @@ use Yiisoft\Injector\Injector;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Test\Support\Log\SimpleLogger;
 use Yiisoft\Queue\Exception\MessageFailureException;
-use Yiisoft\Queue\Message\Message;
+use Yiisoft\Queue\Message\SimpleMessage;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareDispatcher;
 use Yiisoft\Queue\Middleware\Consume\ConsumeMiddlewareFactoryInterface;
@@ -35,7 +35,7 @@ final class WorkerTest extends TestCase
     #[DataProvider('messageHandledDataProvider')]
     public function testMessageHandled(mixed $handler, array $containerServices): void
     {
-        $message = new Message('simple', ['test-data']);
+        $message = new SimpleMessage('simple', ['test-data']);
         $logger = new SimpleLogger();
         $container = new SimpleContainer($containerServices);
         $handlers = ['simple' => $handler];
@@ -90,7 +90,7 @@ final class WorkerTest extends TestCase
     {
         $this->expectExceptionMessage('Queue handler for message type "simple" does not exist');
 
-        $message = new Message('simple', ['test-data']);
+        $message = new SimpleMessage('simple', ['test-data']);
         $handler = new FakeHandler();
         $container = new SimpleContainer([FakeHandler::class => $handler]);
         $handlers = ['simple' => [FakeHandler::class, 'undefinedMethod']];
@@ -106,7 +106,7 @@ final class WorkerTest extends TestCase
     {
         $this->expectExceptionMessage('Queue handler for message type "simple" does not exist');
 
-        $message = new Message('simple', ['test-data']);
+        $message = new SimpleMessage('simple', ['test-data']);
         $logger = new SimpleLogger();
         $handler = new FakeHandler();
         $container = new SimpleContainer([FakeHandler::class => $handler]);
@@ -122,7 +122,7 @@ final class WorkerTest extends TestCase
     public function testMessageFailWithDefinitionClassNotFoundInContainerHandler(): void
     {
         $this->expectExceptionMessage('Queue handler for message type "simple" does not exist');
-        $message = new Message('simple', ['test-data']);
+        $message = new SimpleMessage('simple', ['test-data']);
         $container = new SimpleContainer();
         $handlers = ['simple' => [FakeHandler::class, 'handle']];
 
@@ -135,7 +135,7 @@ final class WorkerTest extends TestCase
 
     public function testMessageFailWithDefinitionHandlerException(): void
     {
-        $message = new Message('simple', ['test-data']);
+        $message = new SimpleMessage('simple', ['test-data']);
         $logger = new SimpleLogger();
         $handler = new FakeHandler();
         $container = new SimpleContainer([FakeHandler::class => $handler]);
@@ -163,7 +163,7 @@ final class WorkerTest extends TestCase
 
     public function testHandlerNotFoundInContainer(): void
     {
-        $message = new Message('nonexistent', ['test-data']);
+        $message = new SimpleMessage('nonexistent', ['test-data']);
         $container = new SimpleContainer();
         $handlers = [];
 
@@ -178,7 +178,7 @@ final class WorkerTest extends TestCase
 
     public function testHandlerInContainerNotImplementingInterface(): void
     {
-        $message = new Message('invalid', ['test-data']);
+        $message = new SimpleMessage('invalid', ['test-data']);
         $container = new SimpleContainer([
             'invalid' => new class {
                 public function handle(): void {}
@@ -197,7 +197,7 @@ final class WorkerTest extends TestCase
 
     public function testMessageFailureIsHandledSuccessfully(): void
     {
-        $message = new Message('simple', null);
+        $message = new SimpleMessage('simple', null);
         /** @var MockObject&QueueInterface $queue */
         $queue = $this->createMock(QueueInterface::class);
         $queue->method('getName')->willReturn('test-queue');
@@ -212,7 +212,7 @@ final class WorkerTest extends TestCase
         $consumeMiddlewareFactory->method('createConsumeMiddleware')->willReturn($consumeMiddleware);
         $consumeDispatcher = new ConsumeMiddlewareDispatcher($consumeMiddlewareFactory, 'simple');
 
-        $finalMessage = new Message('final', null);
+        $finalMessage = new SimpleMessage('final', null);
         /** @var FailureMiddlewareInterface&MockObject $failureMiddleware */
         $failureMiddleware = $this->createMock(FailureMiddlewareInterface::class);
         $failureMiddleware->method('processFailure')->willReturn(new FailureHandlingRequest($finalMessage, $originalException, $queue));
@@ -240,7 +240,7 @@ final class WorkerTest extends TestCase
 
     public function testStaticMethodHandler(): void
     {
-        $message = new Message('static-handler', ['test-data']);
+        $message = new SimpleMessage('static-handler', ['test-data']);
         $container = new SimpleContainer();
         $handlers = [
             'static-handler' => StaticMessageHandler::handle(...),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Tests pass?   | ✔️

Example of custom message class:
```php
final class SmsNotification extends Message
{
    private const TYPE = 'sms';

    public function __construct(
        public readonly string $number,
        public readonly string $text,
    ) {}

    public static function fromData(string $type, mixed $data): MessageInterface
    {
        if ($type !== self::TYPE) {
            throw new InvalidArgumentException("Unsupported message type: $type");
        }

        return new self(
            number: $data['number'] ?? throw new InvalidArgumentException('Number is required.'),
            text: $data['text'] ?? throw new InvalidArgumentException('Text is required.'),
        );
    }

    public function getType(): string
    {
        return self::TYPE;
    }

    public function getData(): mixed
    {
        return [
            'number' => $this->number,
            'text' => $this->text,
        ];
    }
}
```