### PR TITLE
Clarify queue package positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Static analysis](https://github.com/yiisoft/queue/actions/workflows/static.yml/badge.svg?branch=master)](https://github.com/yiisoft/queue/actions/workflows/static.yml?query=branch%3Amaster)
 [![type-coverage](https://shepherd.dev/github/yiisoft/queue/coverage.svg)](https://shepherd.dev/github/yiisoft/queue)
 
-An extension for running tasks asynchronously via queues.
+A framework-agnostic PHP queue library for running tasks asynchronously, best used with Yii 3 applications.
 
 ## Requirements
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "yiisoft/queue",
-    "description": "Queue Extension which supported DB, Redis, RabbitMQ, Beanstalk, SQS and Gearman",
+    "description": "Framework-agnostic PHP queue library for asynchronous tasks, best used with Yii 3",
     "type": "library",
     "keywords": [
         "yii",

--- a/docs/guide/en/README.md
+++ b/docs/guide/en/README.md
@@ -1,5 +1,7 @@
 # Yii Queue documentation
 
+Yii Queue is a framework-agnostic PHP queue library for running tasks asynchronously, best used with Yii 3 applications.
+
 ## Install and configure
 
 - [Prerequisites and installation](prerequisites-and-installation.md)


### PR DESCRIPTION
## Summary
- Replace extension wording with framework-agnostic queue library wording in README.
- Add the same positioning to the guide index.
- Update the Composer package description accordingly.

## Tests
- make composer NO_TTY=1 ARGS="validate --strict"