### PR TITLE
Fix #169: Collect call location in `QueueCollector`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## 1.0.0 under development
 
 - Initial release.
+- Enh #300: Collect call location for `push()` and `status()` in `QueueCollector` (WarLikeLaux)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,3 @@
 ## 1.0.0 under development
 
 - Initial release.
-- Enh #300: Collect call location for `push()` and `status()` in `QueueCollector` (WarLikeLaux)

--- a/src/Debug/QueueCollector.php
+++ b/src/Debug/QueueCollector.php
@@ -33,7 +33,7 @@ final class QueueCollector implements SummaryCollectorInterface
         ];
     }
 
-    public function collectStatus(string $id, MessageStatus $status): void
+    public function collectStatus(string $id, MessageStatus $status, string $line): void
     {
         if (!$this->isActive()) {
             return;
@@ -42,10 +42,11 @@ final class QueueCollector implements SummaryCollectorInterface
         $this->statuses[] = [
             'id' => $id,
             'status' => $status->key(),
+            'line' => $line,
         ];
     }
 
-    public function collectPush(string $queueName, MessageInterface $message): void
+    public function collectPush(string $queueName, MessageInterface $message, string $line): void
     {
         if (!$this->isActive()) {
             return;
@@ -53,6 +54,7 @@ final class QueueCollector implements SummaryCollectorInterface
 
         $this->pushes[$queueName][] = [
             'message' => $message,
+            'line' => $line,
         ];
     }
 

--- a/src/Debug/QueueDecorator.php
+++ b/src/Debug/QueueDecorator.php
@@ -17,16 +17,22 @@ final class QueueDecorator implements QueueInterface
 
     public function status(string|int $id): MessageStatus
     {
+        /** @psalm-var array{file: string, line: int} $callStack */
+        $callStack = debug_backtrace()[0];
+
         $result = $this->queue->status($id);
-        $this->collector->collectStatus((string) $id, $result);
+        $this->collector->collectStatus((string) $id, $result, $callStack['file'] . ':' . $callStack['line']);
 
         return $result;
     }
 
     public function push(MessageInterface $message): MessageInterface
     {
+        /** @psalm-var array{file: string, line: int} $callStack */
+        $callStack = debug_backtrace()[0];
+
         $message = $this->queue->push($message);
-        $this->collector->collectPush($this->queue->getName(), $message);
+        $this->collector->collectPush($this->queue->getName(), $message, $callStack['file'] . ':' . $callStack['line']);
         return $message;
     }
 

--- a/tests/Unit/Debug/QueueCollectorTest.php
+++ b/tests/Unit/Debug/QueueCollectorTest.php
@@ -27,9 +27,9 @@ final class QueueCollectorTest extends AbstractCollectorTestCase
      */
     protected function collectTestData(CollectorInterface $collector): void
     {
-        $collector->collectStatus('12345', MessageStatus::DONE);
-        $collector->collectPush('chan1', $this->pushMessage);
-        $collector->collectPush('chan2', $this->pushMessage);
+        $collector->collectStatus('12345', MessageStatus::DONE, 'status.php:11');
+        $collector->collectPush('chan1', $this->pushMessage, 'push.php:21');
+        $collector->collectPush('chan2', $this->pushMessage, 'push.php:31');
         $collector->collectWorkerProcessing(
             $this->pushMessage,
             new StubQueue('chan1'),
@@ -62,11 +62,13 @@ final class QueueCollectorTest extends AbstractCollectorTestCase
             'chan1' => [
                 [
                     'message' => $this->pushMessage,
+                    'line' => 'push.php:21',
                 ],
             ],
             'chan2' => [
                 [
                     'message' => $this->pushMessage,
+                    'line' => 'push.php:31',
                 ],
             ],
         ], $pushes);
@@ -74,6 +76,7 @@ final class QueueCollectorTest extends AbstractCollectorTestCase
             [
                 'id' => '12345',
                 'status' => 'done',
+                'line' => 'status.php:11',
             ],
         ], $statuses);
         $this->assertEquals(

--- a/tests/Unit/Debug/QueueDecoratorTest.php
+++ b/tests/Unit/Debug/QueueDecoratorTest.php
@@ -42,6 +42,50 @@ final class QueueDecoratorTest extends TestCase
         $decorator->push($message);
     }
 
+    public function testPushCollectsCallLocation(): void
+    {
+        $message = $this->createMock(MessageInterface::class);
+        $queue = $this->createMock(QueueInterface::class);
+        $queue->method('getName')->willReturn('test-queue');
+        $queue->method('push')->willReturn($message);
+        $collector = new QueueCollector();
+        $collector->startup();
+        $decorator = new QueueDecorator(
+            $queue,
+            $collector,
+        );
+
+        $line = __LINE__ + 1;
+        $decorator->push($message);
+
+        $collected = $collector->getCollected();
+        $this->assertSame(
+            ['message' => $message, 'line' => __FILE__ . ':' . $line],
+            $collected['pushes']['test-queue'][0],
+        );
+    }
+
+    public function testStatusCollectsCallLocation(): void
+    {
+        $queue = $this->createMock(QueueInterface::class);
+        $queue->method('status')->willReturn(MessageStatus::WAITING);
+        $collector = new QueueCollector();
+        $collector->startup();
+        $decorator = new QueueDecorator(
+            $queue,
+            $collector,
+        );
+
+        $line = __LINE__ + 1;
+        $decorator->status('42');
+
+        $collected = $collector->getCollected();
+        $this->assertSame(
+            ['id' => '42', 'status' => MessageStatus::WAITING->key(), 'line' => __FILE__ . ':' . $line],
+            $collected['statuses'][0],
+        );
+    }
+
     public function testRun(): void
     {
         $queue = $this->createMock(QueueInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Tests added?  | ✔️
| Tests pass?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #169

## What does this PR do?

`QueueDecorator::push()` and `status()` now capture the caller location (`file:line` via `debug_backtrace()[0]`) and pass it to `QueueCollector`, so the debug panel shows where a queue call originated.

Follows the `EventDispatcherInterfaceProxy` / `EventCollector` pattern from `yii-debug`. Scope is the queue methods named in the issue (`push`, `status`); worker processing is left untouched.

### BC

`QueueCollector::collectPush()` and `collectStatus()` gain a required `$line` parameter. The collector is only called from `QueueDecorator` within this package, and the package is `1.0.0 under development`.
